### PR TITLE
Raise error if trying to train before adding any examples.

### DIFF
--- a/webcam-transfer-learning/index.js
+++ b/webcam-transfer-learning/index.js
@@ -35,6 +35,9 @@ let model;
 const controllerDataset = new ControllerDataset(NUM_CLASSES);
 
 async function train() {
+  if (controllerDataset.xs == null) {
+    throw new Error('Add some examples before training.');
+  }
   trainStatus.innerHTML = 'Training...';
   await tf.nextFrame();
   await tf.nextFrame();


### PR DESCRIPTION
The error only appears in the JS console but at least now the error message
is clear. Before, there would be an error when trying to use the null value
`controllerDataset.xs.shape[0]`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/45)
<!-- Reviewable:end -->
