### PR TITLE
Fix webcam-transfer-learning video stream warning

### DIFF
--- a/webcam-transfer-learning/webcam.js
+++ b/webcam-transfer-learning/webcam.js
@@ -87,7 +87,7 @@ export class Webcam {
         navigator.getUserMedia(
             {video: true},
             stream => {
-              this.webcamElement.src = window.URL.createObjectURL(stream);
+              this.webcamElement.srcObject = stream;
               this.webcamElement.addEventListener('loadeddata', async () => {
                 this.adjustVideoSize(
                     this.webcamElement.videoWidth,


### PR DESCRIPTION
Fix a deprecation warnings about using the `HTMLMediaElement.srcObject` instead of `URL.createObjectURL` api.

> [Deprecation] URL.createObjectURL with media streams is deprecated and will be removed in M68, around July 2018. Please use HTMLMediaElement.srcObject instead. See https://www.chromestatus.com/features/5618491470118912 for more details.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/52)
<!-- Reviewable:end -->
