### PR TITLE
Fix vega-lite config to fix console warnings

### DIFF
--- a/addition-rnn/index.js
+++ b/addition-rnn/index.js
@@ -286,7 +286,7 @@ class AdditionRNNDemo {
             'data': {'values': lossValues},
             'mark': 'line',
             'encoding': {
-              'x': {'field': 'epoch', 'type': 'quantitative'},
+              'x': {'field': 'epoch', 'type': 'ordinal'},
               'y': {'field': 'loss', 'type': 'quantitative'},
               'color': {'field': 'set', 'type': 'nominal'},
             }
@@ -302,7 +302,7 @@ class AdditionRNNDemo {
             'data': {'values': accuracyValues},
             'mark': 'line',
             'encoding': {
-              'x': {'field': 'epoch', 'type': 'quantitative'},
+              'x': {'field': 'epoch', 'type': 'ordinal'},
               'y': {'field': 'accuracy', 'type': 'quantitative'},
               'color': {'field': 'set', 'type': 'nominal'},
             }
@@ -315,7 +315,7 @@ class AdditionRNNDemo {
             'data': {'values': examplesPerSecValues},
             'mark': 'line',
             'encoding': {
-              'x': {'field': 'epoch', 'type': 'quantitative'},
+              'x': {'field': 'epoch', 'type': 'ordinal'},
               'y': {'field': 'examples/s', 'type': 'quantitative'},
             }
           },

--- a/iris/ui.js
+++ b/iris/ui.js
@@ -47,7 +47,7 @@ export function plotLosses(lossValues, epoch, newTrainLoss, newValidationLoss) {
         'data': {'values': lossValues},
         'mark': 'line',
         'encoding': {
-          'x': {'field': 'epoch', 'type': 'quantitative'},
+          'x': {'field': 'epoch', 'type': 'ordinal'},
           'y': {'field': 'loss', 'type': 'quantitative'},
           'color': {'field': 'set', 'type': 'nominal'},
         }
@@ -75,7 +75,7 @@ export function plotAccuracies(
         'data': {'values': accuracyValues},
         'mark': 'line',
         'encoding': {
-          'x': {'field': 'epoch', 'type': 'quantitative'},
+          'x': {'field': 'epoch', 'type': 'ordinal'},
           'y': {'field': 'accuracy', 'type': 'quantitative'},
           'color': {'field': 'set', 'type': 'nominal'},
         }

--- a/mnist/ui.js
+++ b/mnist/ui.js
@@ -71,7 +71,7 @@ export function plotLosses(lossValues) {
         'width': 260,
         'orient': 'vertical',
         'encoding': {
-          'x': {'field': 'batch', 'type': 'quantitative'},
+          'x': {'field': 'batch', 'type': 'ordinal'},
           'y': {'field': 'loss', 'type': 'quantitative'},
           'color': {'field': 'set', 'type': 'nominal', 'legend': null},
         }
@@ -90,7 +90,7 @@ export function plotAccuracies(accuracyValues) {
         'mark': {'type': 'line', 'legend': null},
         'orient': 'vertical',
         'encoding': {
-          'x': {'field': 'batch', 'type': 'quantitative'},
+          'x': {'field': 'batch', 'type': 'ordinal'},
           'y': {'field': 'accuracy', 'type': 'quantitative'},
           'color': {'field': 'set', 'type': 'nominal', 'legend': null},
         }

--- a/polynomial-regression-core/ui.js
+++ b/polynomial-regression-core/ui.js
@@ -58,14 +58,14 @@
        {
          'mark': 'point',
          'encoding': {
-           'x': {'field': 'x', 'type': 'quantitative'},
+           'x': {'field': 'x', 'type': 'ordinal'},
            'y': {'field': 'y', 'type': 'quantitative'}
          }
        },
        {
          'mark': 'line',
          'encoding': {
-           'x': {'field': 'x', 'type': 'quantitative'},
+           'x': {'field': 'x', 'type': 'ordinal'},
            'y': {'field': 'pred', 'type': 'quantitative'},
            'color': {'value': 'tomato'}
          },


### PR DESCRIPTION
The vega config had quantitative style for both 'x' and 'y', which leads to a warning in vega-lite.  The expectation is that one axis will be of type 'temporal' or (in this case) 'ordinal'.

You can play around with vega-lite configs easily with 
https://vega.github.io/editor/#/edited

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/59)
<!-- Reviewable:end -->
