### PR TITLE
Use Int32Array instead of Uint8Array for labels in mnist-node example.

### DIFF
--- a/mnist-node/data.js
+++ b/mnist-node/data.js
@@ -126,7 +126,7 @@ async function loadLabels(filename) {
   const labels = [];
   let index = headerBytes;
   while (index < buffer.byteLength) {
-    const array = new Uint8Array(recordBytes);
+    const array = new Int32Array(recordBytes);
     for (let i = 0; i < recordBytes; i++) {
       array[i] = buffer.readUInt8(index++);
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/91)
<!-- Reviewable:end -->
