### PR TITLE
polynomial-regression-core: fix scalar types

### DIFF
--- a/polynomial-regression-core/data.js
+++ b/polynomial-regression-core/data.js
@@ -27,7 +27,7 @@ export function generateData(numPoints, coeff, sigma = 0.04) {
     const xs = tf.randomUniform([numPoints], -1, 1);
 
     // Generate polynomial data
-    const three = tf.scalar(3, 'int32');
+    const three = tf.scalar(3);
     const ys = a.mul(xs.pow(three))
       .add(b.mul(xs.square()))
       .add(c.mul(xs))

--- a/polynomial-regression-core/index.js
+++ b/polynomial-regression-core/index.js
@@ -63,10 +63,10 @@ const optimizer = tf.train.sgd(learningRate);
 function predict(x) {
   // y = a * x ^ 3 + b * x ^ 2 + c * x + d
   return tf.tidy(() => {
-    return a.mul(x.pow(tf.scalar(3, 'int32')))
-      .add(b.mul(x.square()))
-      .add(c.mul(x))
-      .add(d);
+    return a.mul(x.pow(tf.scalar(3))) // a * x ^ 3
+      .add(b.mul(x.square())) // + b * x ^ 2
+      .add(c.mul(x)) // + c * x
+      .add(d); // + d
   });
 }
 


### PR DESCRIPTION
Use float scalars instead of int32 scalars.

Otherwise, the code was throwing this error on tfjs-node:
`cannot compute Pow as input #1 was expected to be a float tensor but is a int32 tensor`.

Also, this incorporates comments from
https://github.com/tensorflow/tfjs-website/pull/59 and https://github.com/tensorflow/tfjs-website/pull/108.