### PR TITLE
Update t-sne example to point to 0.2.0.

### DIFF
--- a/tsne-mnist-canvas/package.json
+++ b/tsne-mnist-canvas/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@tensorflow/tfjs": "^0.12.0",
     "d3": "^5.2.0",
-    "@tensorflow/tfjs-tsne": "0.1.0"
+    "@tensorflow/tfjs-tsne": "0.2.0"
   },
   "scripts": {
     "watch": "NODE_ENV=development parcel --no-hmr --open index.html ",

--- a/tsne-mnist-canvas/yarn.lock
+++ b/tsne-mnist-canvas/yarn.lock
@@ -63,9 +63,9 @@
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.7.0.tgz#6bee18a220ece102a56be785cd1c67028f968a63"
 
-"@tensorflow/tfjs-tsne@0.1.0":
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-tsne/-/tfjs-tsne-0.1.0.tgz#9083d9b86488d13f195d3d3cc662ba107e89ad50"
+"@tensorflow/tfjs-tsne@0.2.0":
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-tsne/-/tfjs-tsne-0.2.0.tgz#ed6e3320f5c2d179afd89637ef7379eb00813270"
 
 "@tensorflow/tfjs@^0.12.0":
   version "0.12.0"


### PR DESCRIPTION
Fixes https://github.com/tensorflow/tfjs-tsne/issues/55

The example still gives me strange results, but it doesn't throw an error:
![image](https://user-images.githubusercontent.com/1100749/42953659-ea754fb0-8b48-11e8-91d8-fb3a31737b0f.png)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/116)
<!-- Reviewable:end -->
