### PR TITLE
[boston-housing] Add a one-hidden-layer NN option; use leCunNormal initializer

### DIFF
--- a/boston-housing/index.html
+++ b/boston-housing/index.html
@@ -49,7 +49,8 @@ limitations under the License.
     <textarea rows="3" cols="60" readonly="true" id="baselineStatus">Baseline not computed...</textarea>
     <div id="buttons">
       <button id="simple-mlr">Train Linear Regressor</button>
-      <button id="nn-mlr">Train Neural Network Regressor</button>
+      <button id="nn-mlr-1hidden">Train Neural Network Regressor (1 hidden layer)</button>
+      <button id="nn-mlr-2hidden">Train Neural Network Regressor (2 hidden layers)</button>
     </div>
   </div>
   <script src="index.js"></script>

--- a/boston-housing/index.js
+++ b/boston-housing/index.js
@@ -70,7 +70,7 @@ export function multiLayerPerceptronRegressionModel1Hidden() {
   model.add(tf.layers.dense({
     inputShape: [bostonData.numFeatures],
     units: 50,
-    // activation: 'sigmoid',
+    activation: 'sigmoid',
     kernelInitializer: 'leCunNormal'
   }));
   model.add(tf.layers.dense({units: 1}));

--- a/boston-housing/index.js
+++ b/boston-housing/index.js
@@ -51,9 +51,31 @@ export const arraysToTensors = () => {
  *
  * @returns {tf.Sequential} The linear regression model.
  */
-export const linearRegressionModel = () => {
+export function linearRegressionModel() {
   const model = tf.sequential();
   model.add(tf.layers.dense({inputShape: [bostonData.numFeatures], units: 1}));
+
+  model.summary();
+  return model;
+};
+
+/**
+ * Builds and returns Multi Layer Perceptron Regression Model
+ * with 1 hidden layers, each with 10 units activated by sigmoid.
+ *
+ * @returns {tf.Sequential} The multi layer perceptron regression model.
+ */
+export function multiLayerPerceptronRegressionModel1Hidden() {
+  const model = tf.sequential();
+  model.add(tf.layers.dense({
+    inputShape: [bostonData.numFeatures],
+    units: 50,
+    // activation: 'sigmoid',
+    kernelInitializer: 'leCunNormal'
+  }));
+  model.add(tf.layers.dense({units: 1}));
+
+  model.summary();
   return model;
 };
 
@@ -61,18 +83,24 @@ export const linearRegressionModel = () => {
  * Builds and returns Multi Layer Perceptron Regression Model
  * with 2 hidden layers, each with 10 units activated by sigmoid.
  *
- * @returns {tf.Sequential} The multi layer perceptron regression model.
+ * @returns {tf.Sequential} The multi layer perceptron regression mode  l.
  */
-export const multiLayerPerceptronRegressionModel = () => {
+export function multiLayerPerceptronRegressionModel2Hidden() {
   const model = tf.sequential();
   model.add(tf.layers.dense({
     inputShape: [bostonData.numFeatures],
     units: 50,
-    activation: 'sigmoid'
+    activation: 'sigmoid',
+    kernelInitializer: 'leCunNormal'
   }));
-  model.add(tf.layers.dense({units: 50, activation: 'sigmoid'}));
+  model.add(tf.layers.dense({
+    units: 50,
+    activation: 'sigmoid',
+    kernelInitializer: 'leCunNormal'
+  }));
   model.add(tf.layers.dense({units: 1}));
 
+  model.summary();
   return model;
 };
 

--- a/boston-housing/package.json
+++ b/boston-housing/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.13.0",
+    "@tensorflow/tfjs": "^0.13.1",
     "papaparse": "^4.5.0",
     "vega-embed": "^3.18.1",
     "vega-lite": "^2.3.1"

--- a/boston-housing/ui.js
+++ b/boston-housing/ui.js
@@ -17,7 +17,7 @@
 
 import renderChart from 'vega-embed';
 
-import {linearRegressionModel, multiLayerPerceptronRegressionModel, run} from '.';
+import {linearRegressionModel, multiLayerPerceptronRegressionModel1Hidden, multiLayerPerceptronRegressionModel2Hidden, run} from '.';
 
 const statusElement = document.getElementById('status');
 export const updateStatus = (message) => {
@@ -31,7 +31,10 @@ export const updateBaselineStatus = (message) => {
 
 export const setup = async () => {
   const trainSimpleLinearRegression = document.getElementById('simple-mlr');
-  const trainNeuralNetworkLinearRegression = document.getElementById('nn-mlr');
+  const trainNeuralNetworkLinearRegression1Hidden =
+      document.getElementById('nn-mlr-1hidden');
+  const trainNeuralNetworkLinearRegression2Hidden =
+      document.getElementById('nn-mlr-2hidden');
 
   trainSimpleLinearRegression.addEventListener('click', async (e) => {
     const model = linearRegressionModel();
@@ -39,11 +42,19 @@ export const setup = async () => {
     await run(model);
   }, false);
 
-  trainNeuralNetworkLinearRegression.addEventListener('click', async (e) => {
-    const model = multiLayerPerceptronRegressionModel();
-    losses = [];
-    await run(model);
-  }, false);
+  trainNeuralNetworkLinearRegression1Hidden.addEventListener(
+      'click', async () => {
+        const model = multiLayerPerceptronRegressionModel1Hidden();
+        losses = [];
+        await run(model);
+      }, false);
+
+  trainNeuralNetworkLinearRegression2Hidden.addEventListener(
+      'click', async () => {
+        const model = multiLayerPerceptronRegressionModel2Hidden();
+        losses = [];
+        await run(model);
+      }, false);
 };
 
 let losses = [];

--- a/boston-housing/yarn.lock
+++ b/boston-housing/yarn.lock
@@ -45,33 +45,33 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.0.tgz#7496c3f16430fbea823c53e3bd3a046d23618f90"
+"@tensorflow/tfjs-converter@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.1.tgz#a07ede029434aa54f374fb31b029af9a4e2daa0c"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.0.tgz#9e9469a986f935e75839d280c540bc214e5ad418"
+"@tensorflow/tfjs-core@0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.2.tgz#edb0e4b9e42b04ca113a0ce80f211b22e2c85552"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"
     "@types/webgl2" "~0.0.4"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.0.tgz#33a26d3379cbce64a63901bad3cbd65d37e66b48"
+"@tensorflow/tfjs-layers@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.1.tgz#08173c4ef16090821946d37d41a1fd21011afb00"
 
-"@tensorflow/tfjs@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.0.tgz#5e3ac0a6ddb6a5a9e5f927d6ab5e987f76129ffa"
+"@tensorflow/tfjs@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.1.tgz#67f5250197bd4da21771ee2d790c057186a6ef20"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.6.0"
-    "@tensorflow/tfjs-core" "0.13.0"
-    "@tensorflow/tfjs-layers" "0.8.0"
+    "@tensorflow/tfjs-converter" "0.6.1"
+    "@tensorflow/tfjs-core" "0.13.2"
+    "@tensorflow/tfjs-layers" "0.8.1"
 
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"


### PR DESCRIPTION
* Adding the one-hidden-layer NN fits the teaching material
* leCunNormal initailizer leads to more stable and on-average better
  training results from the one-hidden-layer and two-hidden-layer NNs.

  For example, see final test-set MSEs from:

  - 2 hidden layers, default kernel initializer:
    17.2148, 12.8895, 13.1877, 13.5261
  - 2 hidden layers, leCunNormal kernel initializer:
    12.1388, 11.4624, 13.4111, 12.1905

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/141)
<!-- Reviewable:end -->
