### PR TITLE
[iris] Add confusion matrix.

### DIFF
--- a/iris/index.html
+++ b/iris/index.html
@@ -155,6 +155,10 @@ limitations under the License.
         <div id="horizontal-section">
           <div class="canvases" id="lossCanvas"></div>
           <div class="canvases" id="accuracyCanvas"></div>
+          <div>
+            <div>Confusion Matrix (on validation set)</div>
+            <canvas id="confusion-matrix"></canvas>
+          </div>
         </div>
 
         <div id="evaluate">

--- a/iris/index.js
+++ b/iris/index.js
@@ -21,6 +21,48 @@ import * as data from './data';
 import * as loader from './loader';
 import * as ui from './ui';
 
+// TODO(cais): Remove in favor of tf.confusionMatrix once it's available.
+/**
+ * Calcualte the confusion matrix.
+ *
+ * @param {tf.Tensor} labels The target labels, assumed to be 0-based integers
+ *   for the categories. The shape is `[numExamples]`, where
+ *   `numClasses` is the number of possible classes.
+ * @param {tf.Tensor} predictions The predicted probabilities, assumed to be
+ *   0-based integers for the categories. Must have the same shape as `labels`.
+ * @param {number} numClasses Number of all classes, if not provided,
+ *   will calculate from both `labels` and `predictions`.
+ * @return {tf.Tensor} The confusion matrix as a 2D tf.Tensor.
+ */
+function confusionMatrix(labels, predictions, numClasses) {
+  tf.util.assert(
+      numClasses == null || numClasses > 0 && Number.isInteger(numClasses),
+      `If provided, numClasses must be a positive integer, ` +
+          `but got ${numClasses}`);
+  tf.util.assert(
+      labels.rank === 1,
+      `Expected the rank of labels to be 1, but got ${labels.rank}`);
+  tf.util.assert(
+      predictions.rank === 1,
+      `Expected the rank of predictions to be 1, ` +
+          `but got ${predictions.rank}`);
+
+  if (numClasses == null) {
+    // If numClasses is not provided, determine it.
+    console.log(labels.max());
+    labels.max().print();
+    const labelClasses = labels.max().get();
+    const predictionClasses = predictions.max().get();
+    console.log(labelClasses, predictionClasses);
+    numClasses = 
+          (labelClasses > predictionClasses ? labelClasses : predictionClasses) + 1;
+  }
+
+  const oneHotLabels = tf.oneHot(labels, numClasses);
+  const oneHotPredictions = tf.oneHot(predictions, numClasses);
+  return oneHotLabels.transpose().matMul(oneHotPredictions);
+}
+
 let model;
 
 /**
@@ -65,6 +107,7 @@ async function trainModel(xTrain, yTrain, xTest, yTest) {
         // Plot the loss and accuracy values at the end of every training epoch.
         ui.plotLosses(lossValues, epoch, logs.loss, logs.val_loss);
         ui.plotAccuracies(accuracyValues, epoch, logs.acc, logs.val_acc);
+        calculateAndDrawConfusionMatrix(model, xTest, yTest);
       },
     }
   });
@@ -103,6 +146,19 @@ async function predictOnManualInput(model) {
 }
 
 /**
+ * Draw confusion matrix.
+ */
+function calculateAndDrawConfusionMatrix(model, xTest, yTest) {
+  tf.tidy(() => {
+    const predictOut = model.predict(xTest);
+    const yPred = predictOut.argMax(-1);
+
+    const confusionMat = confusionMatrix(yTest.argMax(-1), yPred);
+    ui.drawConfusionMatrix(confusionMat);
+  });
+}
+
+/**
  * Run inference on some test Iris flower data.
  *
  * @param model The instance of `tf.Model` to run the inference with.
@@ -120,6 +176,7 @@ async function evaluateModelOnTestData(model, xTest, yTest) {
     const yPred = predictOut.argMax(-1);
     ui.renderEvaluateTable(
         xData, yTrue, yPred.dataSync(), predictOut.dataSync());
+    calculateAndDrawConfusionMatrix(model, xTest, yTest);
   });
 
   predictOnManualInput(model);

--- a/iris/index.js
+++ b/iris/index.js
@@ -28,7 +28,7 @@ import * as ui from './ui';
  *
  * @param {tf.Tensor} labels The target labels, assumed to be 0-based integers
  *   for the categories. The shape is `[numExamples]`, where
- *   `numClasses` is the number of possible classes.
+ *   `numExamples` is the number of examples included.
  * @param {tf.Tensor} predictions The predicted probabilities, assumed to be
  *   0-based integers for the categories. Must have the same shape as `labels`.
  * @param {number} numClasses Number of all classes, if not provided,
@@ -49,6 +49,10 @@ function confusionMatrix(labels, predictions, numClasses) {
       predictions.rank === 1,
       `Expected the rank of predictions to be 1, ` +
           `but got ${predictions.rank}`);
+  tf.util.assert(
+      labels.shape[0] === predictions.shape[0],
+      `Mismatch in the number of examples: ` +
+      `${labels.shape[0]} vs. ${predictions.shape[0]}`);
 
   if (numClasses == null) {
     // If numClasses is not provided, determine it.

--- a/iris/index.js
+++ b/iris/index.js
@@ -22,6 +22,7 @@ import * as loader from './loader';
 import * as ui from './ui';
 
 // TODO(cais): Remove in favor of tf.confusionMatrix once it's available.
+//   https://github.com/tensorflow/tfjs/issues/771
 /**
  * Calcualte the confusion matrix.
  *
@@ -32,7 +33,9 @@ import * as ui from './ui';
  *   0-based integers for the categories. Must have the same shape as `labels`.
  * @param {number} numClasses Number of all classes, if not provided,
  *   will calculate from both `labels` and `predictions`.
- * @return {tf.Tensor} The confusion matrix as a 2D tf.Tensor.
+ * @return {tf.Tensor} The confusion matrix as a 2D tf.Tensor. The rows
+ *   correspond to the truth classes and the columns correspond to the
+ *   predicted classes.
  */
 function confusionMatrix(labels, predictions, numClasses) {
   tf.util.assert(

--- a/iris/index.js
+++ b/iris/index.js
@@ -56,11 +56,8 @@ function confusionMatrix(labels, predictions, numClasses) {
 
   if (numClasses == null) {
     // If numClasses is not provided, determine it.
-    console.log(labels.max());
-    labels.max().print();
     const labelClasses = labels.max().get();
     const predictionClasses = predictions.max().get();
-    console.log(labelClasses, predictionClasses);
     numClasses = 
           (labelClasses > predictionClasses ? labelClasses : predictionClasses) + 1;
   }

--- a/iris/package.json
+++ b/iris/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.13.0",
+    "@tensorflow/tfjs": "^0.13.1",
     "vega-embed": "^3.0.0"
   },
   "scripts": {

--- a/iris/ui.js
+++ b/iris/ui.js
@@ -97,6 +97,42 @@ export function getManualInputData() {
   ];
 }
 
+const confusionMatrixCanvas = document.getElementById('confusion-matrix');
+
+/**
+ * Render a confusion matrix.
+ * 
+ * @param {tf.Tensor} confusionMat Confusion matrix as a 2D tf.Tensor object.
+ *   The rows of it are assumed to correspond to the truth classes.
+ */
+export function drawConfusionMatrix(confusionMat) {
+  const w = confusionMatrixCanvas.width;
+  const h = confusionMatrixCanvas.height;
+  const ctx = confusionMatrixCanvas.getContext('2d');
+  ctx.clearRect(0, 0, w, h);
+  const n = confusionMat.shape[0];
+  const rawConfusion = confusionMat.dataSync();
+  const normalizedConfusion =
+      confusionMat.div(confusionMat.sum(-1).expandDims(0)).dataSync();
+  for (let i = 0; i < n; ++i) {
+    for (let j = 0; j < n; ++j) {
+      const rgbValue = Math.round(255 * (1 - normalizedConfusion[i * n + j]));
+      ctx.fillStyle = `rgb(${rgbValue}, ${rgbValue}, ${rgbValue})`;
+      ctx.fillRect(w / n * j, h / n * i, w / n, h / n);
+      ctx.stroke();
+      ctx.strokeStyle = '#808080';
+      ctx.rect(w / n * j, h / n * i, w / n, h / n);
+      ctx.stroke();
+      ctx.font = '18px Arial';
+      ctx.fillStyle = '#ff00ff';
+      ctx.fillText(
+          `${rawConfusion[i * n + j]}`,
+          w / n * (j + 0.45), h / n * (i + 0.66));
+      ctx.stroke();
+    }
+  }
+}
+
 export function setManualInputWinnerMessage(message) {
   const winnerElement = document.getElementById('winner');
   winnerElement.textContent = message;

--- a/iris/ui.js
+++ b/iris/ui.js
@@ -103,7 +103,8 @@ const confusionMatrixCanvas = document.getElementById('confusion-matrix');
  * Render a confusion matrix.
  * 
  * @param {tf.Tensor} confusionMat Confusion matrix as a 2D tf.Tensor object.
- *   The rows of it are assumed to correspond to the truth classes.
+ *   The value at row `r` and column `c` is the number of times examples of
+ *   actual class `r` were predicted as class `c`.
  */
 export function drawConfusionMatrix(confusionMat) {
   const w = confusionMatrixCanvas.width;

--- a/iris/yarn.lock
+++ b/iris/yarn.lock
@@ -45,33 +45,33 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.0.tgz#7496c3f16430fbea823c53e3bd3a046d23618f90"
+"@tensorflow/tfjs-converter@0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.1.tgz#a07ede029434aa54f374fb31b029af9a4e2daa0c"
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.0.tgz#9e9469a986f935e75839d280c540bc214e5ad418"
+"@tensorflow/tfjs-core@0.13.2":
+  version "0.13.2"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.2.tgz#edb0e4b9e42b04ca113a0ce80f211b22e2c85552"
   dependencies:
     "@types/seedrandom" "~2.4.27"
     "@types/webgl-ext" "~0.0.29"
     "@types/webgl2" "~0.0.4"
     seedrandom "~2.4.3"
 
-"@tensorflow/tfjs-layers@0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.0.tgz#33a26d3379cbce64a63901bad3cbd65d37e66b48"
+"@tensorflow/tfjs-layers@0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.1.tgz#08173c4ef16090821946d37d41a1fd21011afb00"
 
-"@tensorflow/tfjs@^0.13.0":
-  version "0.13.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.0.tgz#5e3ac0a6ddb6a5a9e5f927d6ab5e987f76129ffa"
+"@tensorflow/tfjs@^0.13.1":
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.1.tgz#67f5250197bd4da21771ee2d790c057186a6ef20"
   dependencies:
-    "@tensorflow/tfjs-converter" "0.6.0"
-    "@tensorflow/tfjs-core" "0.13.0"
-    "@tensorflow/tfjs-layers" "0.8.0"
+    "@tensorflow/tfjs-converter" "0.6.1"
+    "@tensorflow/tfjs-core" "0.13.2"
+    "@tensorflow/tfjs-layers" "0.8.1"
 
 "@types/json-stable-stringify@^1.0.32":
   version "1.0.32"


### PR DESCRIPTION
Currently we use an ad hoc implementation of confusionMatrix. We will switch to tf.confusionMatrix once it is available:
https://github.com/tensorflow/tfjs/issues/771

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/145)
<!-- Reviewable:end -->
