### PR TITLE
[mnist-transfer-learning] Correct the computation of predicted output (winner)

### DIFF
--- a/mnist-transfer-cnn/index.js
+++ b/mnist-transfer-cnn/index.js
@@ -91,7 +91,7 @@ class MnistTransferCNNPredictor {
       try {
         const image = util.textToImageArray(imageText, this.imageSize);
         const predictOut = this.model.predict(image);
-        const winner = predictOut.argMax();
+        const winner = predictOut.argMax(1);
 
         ui.setPredictResults(predictOut.dataSync(), winner.dataSync()[0] + 5);
       } catch (e) {


### PR DESCRIPTION
The axis should be 1 else the returned value is always [0 0 0 0]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/154)
<!-- Reviewable:end -->
