### PR TITLE
[simple-object-detection] Allow some noise objects to obscure target object

### DIFF
--- a/simple-object-detection/index.js
+++ b/simple-object-detection/index.js
@@ -104,7 +104,8 @@ async function runAndVisualizeInference(model) {
   const {images, targets} = await synth.generateExampleBatch(
       numExamples, numCircles, numLineSegments);
 
-  const boundingBoxArray = Array.from(targets.dataSync()).slice(1);
+  const targetsArray = await targets.data();
+  const boundingBoxArray = Array.from(targetsArray).slice(1);
   const t0 = tf.util.now();
   // Runs inference with the model.
   const modelOut = await model.predict(images).data();
@@ -114,8 +115,7 @@ async function runAndVisualizeInference(model) {
   drawBoundingBoxes(canvas, boundingBoxArray, modelOut.slice(1));
 
   // Display the true and predict object classes.
-  const trueClassName =
-      (await targets.data())[0] > 0 ? 'rectangle' : 'triangle';
+  const trueClassName = targetsArray[0] > 0 ? 'rectangle' : 'triangle';
   trueObjectClass.textContent = trueClassName;
 
   // The model predicts a number to indicate the predicted class

--- a/simple-object-detection/index.js
+++ b/simple-object-detection/index.js
@@ -103,15 +103,15 @@ async function runAndVisualizeInference(model) {
   const numLineSegments = 10;
   const {images, targets} = await synth.generateExampleBatch(
       numExamples, numCircles, numLineSegments);
-
-  const targetsArray = await targets.data();
-  const boundingBoxArray = Array.from(targetsArray).slice(1);
+  
   const t0 = tf.util.now();
   // Runs inference with the model.
   const modelOut = await model.predict(images).data();
   inferenceTimeMs.textContent = `${(tf.util.now() - t0).toFixed(1)}`;
 
   // Visualize the true and predicted bounding boxes.
+  const targetsArray = Array.from(await targets.data());
+  const boundingBoxArray = targetsArray.slice(1);
   drawBoundingBoxes(canvas, boundingBoxArray, modelOut.slice(1));
 
   // Display the true and predict object classes.

--- a/simple-object-detection/package.json
+++ b/simple-object-detection/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-node": "0.1.19",
+    "@tensorflow/tfjs-node-gpu": "0.1.20",
     "argparse": "^1.0.10",
     "canvas": "2.0.1",
     "node-fetch": "2.2.1"

--- a/simple-object-detection/package.json
+++ b/simple-object-detection/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs-node-gpu": "0.1.20",
+    "@tensorflow/tfjs-node": "0.1.20",
     "argparse": "^1.0.10",
     "canvas": "2.0.1",
     "node-fetch": "2.2.1"

--- a/simple-object-detection/synthetic_images.js
+++ b/simple-object-detection/synthetic_images.js
@@ -108,13 +108,13 @@ class ObjectDetectionImageSynthesizer {
     const ctx = this.canvas.getContext('2d');
     ctx.clearRect(0, 0, this.w, this.h);  // Clear canvas.
 
-    // Draw circles.
-    for (let i = 0; i < numCircles; ++i) {
+    // Draw circles (1st half).
+    for (let i = 0; i < numCircles / 2; ++i) {
       this.drawCircle(ctx);
     }
 
-    // Draw lines segments.
-    for (let i = 0; i < numLines; ++i) {
+    // Draw lines segments (1st half).
+    for (let i = 0; i < numLines / 2; ++i) {
       this.drawLineSegment(ctx);
     }
 
@@ -153,6 +153,16 @@ class ObjectDetectionImageSynthesizer {
       boundingBox = this.drawTriangle(ctx, centerX, centerY, side, angle);
     }
     ctx.fill();
+
+    // Draw circles (2nd half).
+    for (let i = 0; i < numCircles / 2; ++i) {
+      this.drawCircle(ctx);
+    }
+
+    // Draw lines segments (2nd half).
+    for (let i = 0; i < numLines / 2; ++i) {
+      this.drawLineSegment(ctx);
+    }
 
     return tf.tidy(() => {
       const imageTensor = tf.fromPixels(this.canvas);

--- a/simple-object-detection/synthetic_images.js
+++ b/simple-object-detection/synthetic_images.js
@@ -155,12 +155,12 @@ class ObjectDetectionImageSynthesizer {
     ctx.fill();
 
     // Draw circles (2nd half).
-    for (let i = 0; i < numCircles / 2; ++i) {
+    for (let i = numCircles / 2; i < numCircles; ++i) {
       this.drawCircle(ctx);
     }
 
     // Draw lines segments (2nd half).
-    for (let i = 0; i < numLines / 2; ++i) {
+    for (let i = numLines / 2; i < numLines; ++i) {
       this.drawLineSegment(ctx);
     }
 

--- a/simple-object-detection/train.js
+++ b/simple-object-detection/train.js
@@ -23,7 +23,7 @@ const canvas = require('canvas');
 const tf = require('@tensorflow/tfjs');
 const synthesizer = require('./synthetic_images');
 const fetch = require('node-fetch');
-require('@tensorflow/tfjs-node');
+require('@tensorflow/tfjs-node-gpu');
 
 global.fetch = fetch;
 

--- a/simple-object-detection/train.js
+++ b/simple-object-detection/train.js
@@ -23,7 +23,15 @@ const canvas = require('canvas');
 const tf = require('@tensorflow/tfjs');
 const synthesizer = require('./synthetic_images');
 const fetch = require('node-fetch');
-require('@tensorflow/tfjs-node-gpu');
+
+// To train the model using CUDA/CuDNN,
+//   1) Make sure you have a CUDA-enabled GPU on your system.
+//   2) Install the necessary NVIDIA driver, CUDA toolkit and CuDNN library.
+//   3) Change the "@tensorflow/tfjs-node" dependency to
+//      "@tensorflow/tfjs-node-gpu" in package.json.
+//   4) Change the following line to:
+//      require('@tensorflow/tfjs-node-gpu');
+require('@tensorflow/tfjs-node');
 
 global.fetch = fetch;
 
@@ -69,12 +77,12 @@ function customLossFunction(yTrue, yPred) {
 
 /**
  * Loads MobileNet, removes the top part, and freeze all the layers.
- * 
+ *
  * The top removal and layer freezing are preparation for transfer learning.
  *
  * Also gets handles to the layers that will be unfrozen during the fine-tuning
  * phase of the training.
- * 
+ *
  * @return {tf.Model} The truncated MobileNet, with all layers frozen.
  */
 async function loadTruncatedBase() {

--- a/simple-object-detection/yarn.lock
+++ b/simple-object-detection/yarn.lock
@@ -688,45 +688,49 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
 
-"@tensorflow/tfjs-converter@0.6.5":
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.5.tgz#71d28889e4236e8178d8cb849e741751011cb1f7"
+"@tensorflow/tfjs-converter@0.6.6":
+  version "0.6.6"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-converter/-/tfjs-converter-0.6.6.tgz#1688ca889b63548434dc4e9f0447f568488cae9e"
+  integrity sha512-zDpDY6hyoXw6yEHd8CZrs7VL1Kl/kFhW5JcJWC7h2xqsMxk09v7OSNa4YQfJWJQeCXVStjK9VOqLSkwTETwPrw==
   dependencies:
     "@types/long" "~3.0.32"
     protobufjs "~6.8.6"
 
-"@tensorflow/tfjs-core@0.13.8":
-  version "0.13.8"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.8.tgz#90f73107df6ad7f1c13ff9d765a3d3d3997af1cb"
+"@tensorflow/tfjs-core@0.13.10":
+  version "0.13.10"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-core/-/tfjs-core-0.13.10.tgz#dab52099542d683fa655fb46ac5fec16af43ced6"
+  integrity sha512-hq4wZj9qHDqSCKJ6VWfbSHVo3J2h3i+4pd3KCEIiBiFkwyv571hFQRrYeD3uuXrFm+ZjBDU2Js/Nl9m2kcv4ag==
   dependencies:
     "@types/seedrandom" "2.4.27"
     "@types/webgl-ext" "0.0.30"
     "@types/webgl2" "0.0.4"
     seedrandom "2.4.3"
 
-"@tensorflow/tfjs-layers@0.8.3":
-  version "0.8.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.3.tgz#b3995e668afecf37a1382deeea57e40eee6519b4"
+"@tensorflow/tfjs-layers@0.8.4":
+  version "0.8.4"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.4.tgz#e4786b2886565bd92c29d6c9444a5dac2266ffed"
+  integrity sha512-iKWoWlKxu7yvB09KZnbIUZArICnbTHRE7TC1VnGypqS5s/6Y66/MRYLAJYMZ9ArXp4ijUbJKt92aoXYzvwEV7g==
 
-"@tensorflow/tfjs-node@0.1.19":
-  version "0.1.19"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node/-/tfjs-node-0.1.19.tgz#649ab515f4d9a333e96e9c8600a04caf06d1e446"
-  integrity sha512-iQwUu52H1fZjlwNHB3C0nqIhhfGoHz9o7pu9PTxkcFSAuKRqI4quvt96uT2GS089w+FLFyGwABi2hBjXDsYMJw==
+"@tensorflow/tfjs-node-gpu@0.1.20":
+  version "0.1.20"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node-gpu/-/tfjs-node-gpu-0.1.20.tgz#3e2caf7038c5ec9b883a5c65d6251f7cfe43bef4"
+  integrity sha512-kYT2kpJwSopjrSlD1M0LI+eVOGdcZJvzwfxDEks0lUZEr5LlOiHSQ5Uu5O819BvcIqdIiAHX9nKtjC6HOqzk0Q==
   dependencies:
-    "@tensorflow/tfjs" "^0.13.2"
+    "@tensorflow/tfjs" "~0.13.4"
     adm-zip "^0.4.11"
     bindings "~1.3.0"
     progress "^2.0.0"
     rimraf "^2.6.2"
     tar "^4.4.6"
 
-"@tensorflow/tfjs@^0.13.2":
-  version "0.13.3"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.3.tgz#a44ce32ada34e464d8c596cee10695e0a0ebb5de"
+"@tensorflow/tfjs@~0.13.4":
+  version "0.13.4"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs/-/tfjs-0.13.4.tgz#65e97a453fb4363018d27d25f6648f6351715c10"
+  integrity sha512-IKDUsgrWOZvqrBGne9NC4I6ZrPXUgScYoLsplMLUGoHsSD8CiAslOVI7wl2uDEJhqm1MY3VjHdELnl2f1Fm7kg==
   dependencies:
-    "@tensorflow/tfjs-converter" "0.6.5"
-    "@tensorflow/tfjs-core" "0.13.8"
-    "@tensorflow/tfjs-layers" "0.8.3"
+    "@tensorflow/tfjs-converter" "0.6.6"
+    "@tensorflow/tfjs-core" "0.13.10"
+    "@tensorflow/tfjs-layers" "0.8.4"
 
 "@types/long@^4.0.0":
   version "4.0.0"

--- a/simple-object-detection/yarn.lock
+++ b/simple-object-detection/yarn.lock
@@ -711,10 +711,10 @@
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-0.8.4.tgz#e4786b2886565bd92c29d6c9444a5dac2266ffed"
   integrity sha512-iKWoWlKxu7yvB09KZnbIUZArICnbTHRE7TC1VnGypqS5s/6Y66/MRYLAJYMZ9ArXp4ijUbJKt92aoXYzvwEV7g==
 
-"@tensorflow/tfjs-node-gpu@0.1.20":
+"@tensorflow/tfjs-node@0.1.20":
   version "0.1.20"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node-gpu/-/tfjs-node-gpu-0.1.20.tgz#3e2caf7038c5ec9b883a5c65d6251f7cfe43bef4"
-  integrity sha512-kYT2kpJwSopjrSlD1M0LI+eVOGdcZJvzwfxDEks0lUZEr5LlOiHSQ5Uu5O819BvcIqdIiAHX9nKtjC6HOqzk0Q==
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-node/-/tfjs-node-0.1.20.tgz#df9a023c568943a9fa262916ffd0649998cb718a"
+  integrity sha512-pa/mRWzqUrO+8Q0RbZvIy1uS1+kMZT83VLusGylDBB7qX2Hs2zjk0K2NpmjBocKY+2VRlGBQe8jik3A6E4UTbQ==
   dependencies:
     "@tensorflow/tfjs" "~0.13.4"
     adm-zip "^0.4.11"


### PR DESCRIPTION
- Previously, all the background objects (line segments and circles) were drawn
  before the target objects and hence are in the background.
- In this PR, we allow 50% of the background objects to be drawn after the target
  objects. As a result, some of them will end up on to of the target objects and
  partially cover them.
- The model turns out to be able to handle it. There is an expected slight increase
  in the validation loss due to the partial covering, but the increase doesn't  lead
  to any serious degradation of the object classification or localization quality.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/176)
<!-- Reviewable:end -->
