### PR TITLE
Replace tf.fromPixels with tf.browser.fromPixels

### DIFF
--- a/addition-rnn/package.json
+++ b/addition-rnn/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/boston-housing/package.json
+++ b/boston-housing/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2",
     "papaparse": "^4.5.0"
   },

--- a/cart-pole/package.json
+++ b/cart-pole/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/custom-layer/index.js
+++ b/custom-layer/index.js
@@ -22,7 +22,7 @@ import {antirectifier} from './custom_layer';
 function customLayerDemo() {
   let imgElement = document.getElementById('cat');
   // Layer expects first dimension to be batch, therefore expandDims.
-  const img = tf.fromPixels(imgElement).toFloat().expandDims(0);
+  const img = tf.browser.fromPixels(imgElement).toFloat().expandDims(0);
   const layer = antirectifier();
   const [posTensor, negTensor] = tf.split(layer.apply(img), 2, 3);
   const posCanvas = document.createElement('canvas');

--- a/custom-layer/package.json
+++ b/custom-layer/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.15.0"
+    "@tensorflow/tfjs": "^0.15.1"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",

--- a/custom-layer/package.json
+++ b/custom-layer/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2"
+    "@tensorflow/tfjs": "^0.15.0"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",

--- a/data-csv/package.json
+++ b/data-csv/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "dependencies": {
     "@babel/plugin-transform-runtime": "^7.2.0",
-    "@tensorflow/tfjs": "^0.14.2"
+    "@tensorflow/tfjs": "^0.15.1"
   },
   "scripts": {
     "link-local": "yalc link",

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,12 +47,12 @@ for i in $EXAMPLES; do
   echo "building ${EXAMPLE_NAME}..."
   yarn
   yarn build
-  gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME
-  gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME/dist
-  gsutil -m cp dist/* gs://tfjs-examples/$EXAMPLE_NAME/dist
+  #gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME
+  #gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME/dist
+  #gsutil -m cp dist/* gs://tfjs-examples/$EXAMPLE_NAME/dist
   cd ..
 done
 
-gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.html"
-gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.css"
-gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.js"
+#gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.html"
+#gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.css"
+#gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.js"

--- a/deploy.sh
+++ b/deploy.sh
@@ -47,12 +47,12 @@ for i in $EXAMPLES; do
   echo "building ${EXAMPLE_NAME}..."
   yarn
   yarn build
-  #gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME
-  #gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME/dist
-  #gsutil -m cp dist/* gs://tfjs-examples/$EXAMPLE_NAME/dist
+  gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME
+  gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME/dist
+  gsutil -m cp dist/* gs://tfjs-examples/$EXAMPLE_NAME/dist
   cd ..
 done
 
-#gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.html"
-#gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.css"
-#gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.js"
+gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.html"
+gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.css"
+gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.js"

--- a/iris-fitDataset/package.json
+++ b/iris-fitDataset/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.0"
   },
   "scripts": {

--- a/iris/package.json
+++ b/iris/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/jena-weather/package.json
+++ b/jena-weather/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "0.4.2"
   },
   "scripts": {

--- a/lstm-text-generation/package.json
+++ b/lstm-text-generation/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/mnist-core/package.json
+++ b/mnist-core/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/mnist-transfer-cnn/package.json
+++ b/mnist-transfer-cnn/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/mnist/package.json
+++ b/mnist/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2"
   },
   "scripts": {

--- a/mobilenet/index.js
+++ b/mobilenet/index.js
@@ -63,8 +63,8 @@ async function predict(imgElement) {
 
   const startTime = performance.now();
   const logits = tf.tidy(() => {
-    // tf.fromPixels() returns a Tensor from an image element.
-    const img = tf.fromPixels(imgElement).toFloat();
+    // tf.browser.fromPixels() returns a Tensor from an image element.
+    const img = tf.browser.fromPixels(imgElement).toFloat();
 
     const offset = tf.scalar(127.5);
     // Normalize the image from [0, 255] to [-1, 1].

--- a/mobilenet/package.json
+++ b/mobilenet/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2"
+    "@tensorflow/tfjs": "^0.15.0"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",

--- a/mobilenet/package.json
+++ b/mobilenet/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.15.0"
+    "@tensorflow/tfjs": "^0.15.s1"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",

--- a/polynomial-regression-core/package.json
+++ b/polynomial-regression-core/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "vega-embed": "^3.2.0"
   },
   "scripts": {

--- a/polynomial-regression/package.json
+++ b/polynomial-regression/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2"
+    "@tensorflow/tfjs": "^0.15.1"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",

--- a/sentiment/package.json
+++ b/sentiment/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "vega-embed": "^3.0.0"
   },
   "scripts": {

--- a/simple-object-detection/package.json
+++ b/simple-object-detection/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.15.0",
+    "@tensorflow/tfjs": "^0.15.1",
     "argparse": "^1.0.10",
     "canvas": "2.0.1",
     "node-fetch": "2.2.1"

--- a/simple-object-detection/package.json
+++ b/simple-object-detection/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "0.14.2",
+    "@tensorflow/tfjs": "^0.15.0",
     "argparse": "^1.0.10",
     "canvas": "2.0.1",
     "node-fetch": "2.2.1"

--- a/simple-object-detection/synthetic_images.js
+++ b/simple-object-detection/synthetic_images.js
@@ -165,7 +165,7 @@ class ObjectDetectionImageSynthesizer {
     }
 
     return tf.tidy(() => {
-      const imageTensor = tf.fromPixels(this.canvas);
+      const imageTensor = tf.browser.fromPixels(this.canvas);
       const shapeClassIndicator = isRectangle ? 1 : 0;
       const targetTensor =
           tf.tensor1d([shapeClassIndicator].concat(boundingBox));

--- a/translation/package.json
+++ b/translation/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "vega-embed": "^3.0.0"
   },
   "scripts": {

--- a/tsne-mnist-canvas/package.json
+++ b/tsne-mnist-canvas/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-tsne": "0.2.0",
     "d3": "^5.2.0"
   },

--- a/visualize-convnet/package.json
+++ b/visualize-convnet/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "0.14.1"
+    "@tensorflow/tfjs": "^0.15.1"
   },
   "scripts": {
     "watch": "cross-env NODE_ENV=development parcel index.html --no-hmr --open",

--- a/webcam-transfer-learning/package.json
+++ b/webcam-transfer-learning/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.14.2",
+    "@tensorflow/tfjs": "^0.15.0",
     "vega-embed": "^3.0.0"
   },
   "scripts": {

--- a/webcam-transfer-learning/package.json
+++ b/webcam-transfer-learning/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.15.0",
+    "@tensorflow/tfjs": "^0.15.1",
     "vega-embed": "^3.0.0"
   },
   "scripts": {

--- a/webcam-transfer-learning/webcam.js
+++ b/webcam-transfer-learning/webcam.js
@@ -34,7 +34,7 @@ export class Webcam {
   capture() {
     return tf.tidy(() => {
       // Reads the image as a Tensor from the webcam <video> element.
-      const webcamImage = tf.fromPixels(this.webcamElement);
+      const webcamImage = tf.browser.fromPixels(this.webcamElement);
 
       // Crop the image so we're using the center square of the rectangular
       // webcam.

--- a/website-phishing/package.json
+++ b/website-phishing/package.json
@@ -9,7 +9,7 @@
     "node": ">=8.9.0"
   },
   "dependencies": {
-    "@tensorflow/tfjs": "^0.15.0",
+    "@tensorflow/tfjs": "^0.15.1",
     "@tensorflow/tfjs-vis": "^0.4.2",
     "papaparse": "^4.5.0"
   },


### PR DESCRIPTION
- Replace tf.fromPixels with tf.browser.fromPixels
- Make all examples depend on `0.15.1`

tf.browser.fromPixels() works with the latest 0.15.1. This PR is pending on the release of 0.15.1 to update `yarn.lock` files and run examples manually

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/228)
<!-- Reviewable:end -->
