### PR TITLE
Enable gzip compression on GCS for our hosted examples

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -46,13 +46,11 @@ for i in $EXAMPLES; do
 
   echo "building ${EXAMPLE_NAME}..."
   yarn
+  rm -rf dist .cache
   yarn build
-  gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME
-  gsutil mkdir -p gs://tfjs-examples/$EXAMPLE_NAME/dist
-  gsutil -m cp dist/* gs://tfjs-examples/$EXAMPLE_NAME/dist
+  # Remove the example directory.
+  gsutil -m rm -r gs://tfjs-examples/$EXAMPLE_NAME
+  # Gzip and copy all the dist files. The trailing slash is important.
+  gsutil -m cp -Z -r dist gs://tfjs-examples/$EXAMPLE_NAME/
   cd ..
 done
-
-gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.html"
-gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.css"
-gsutil -m setmeta -h "Cache-Control:private" "gs://tfjs-examples/**.js"


### PR DESCRIPTION
- Enable gzip compression on our example assets
- Enable caching (remove the no-cache: private header)
- Remove the old `dist/` files so we do not accumulate multiple versions.
- Re-uploaded each example by running the `deploy.sh` script

This saves everyone **significant** bandwidth (both GCP and the user). Verified the improvement on PageSpeed Insights: [See addition-rnn as example](https://developers.google.com/speed/pagespeed/insights/?url=https%3A%2F%2Fstorage.googleapis.com%2Ftfjs-examples%2Faddition-rnn%2Fdist%2Findex.html)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/238)
<!-- Reviewable:end -->
