### PR TITLE
[mobilenet] Add timing number without image extraction and preprocessing

### DIFF
--- a/mobilenet/index.js
+++ b/mobilenet/index.js
@@ -61,7 +61,12 @@ const mobilenetDemo = async () => {
 async function predict(imgElement) {
   status('Predicting...');
 
-  const startTime = performance.now();
+  // The first start time includes the time it takes to extract the image
+  // from the HTML and preprocess it, in additon to the predict() call.
+  const startTime1 = performance.now();
+  // The second start time excludes the extraction and preprocessing and
+  // includes only the predict() call.
+  let startTime2;
   const logits = tf.tidy(() => {
     // tf.browser.fromPixels() returns a Tensor from an image element.
     const img = tf.browser.fromPixels(imgElement).toFloat();
@@ -73,14 +78,17 @@ async function predict(imgElement) {
     // Reshape to a single-element batch so we can pass it to predict.
     const batched = normalized.reshape([1, IMAGE_SIZE, IMAGE_SIZE, 3]);
 
+    startTime2 = performance.now();
     // Make a prediction through mobilenet.
     return mobilenet.predict(batched);
   });
 
   // Convert logits to probabilities and class names.
   const classes = await getTopKClasses(logits, TOPK_PREDICTIONS);
-  const totalTime = performance.now() - startTime;
-  status(`Done in ${Math.floor(totalTime)}ms`);
+  const totalTime1 = performance.now() - startTime1;
+  const totalTime2 = performance.now() - startTime2;
+  status(`Done in ${Math.floor(totalTime1)} ms ` +
+      `(not including preprocessing: ${Math.floor(totalTime2)} ms)`);
 
   // Show the classes in the DOM.
   showResults(imgElement, classes);


### PR DESCRIPTION
It turns out that image extraction and preprocessing takes a big fraction of the time.

A typical result (with the new code) looks like:
Done in 76 ms (not including image preprocessing: 21 ms)

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/254)
<!-- Reviewable:end -->
