### PR TITLE
Fix custom layer bug

### DIFF
--- a/custom-layer/.babelrc
+++ b/custom-layer/.babelrc
@@ -1,0 +1,18 @@
+{
+  "presets": [
+    [
+      "env",
+      {
+        "esmodules": false,
+        "targets": {
+          "browsers": [
+            "> 3%"
+          ]
+        }
+      }
+    ]
+  ],
+  "plugins": [
+    "transform-runtime"
+  ]
+}

--- a/custom-layer/index.js
+++ b/custom-layer/index.js
@@ -53,4 +53,8 @@ function tensorToCanvas(tensor, canvas) {
   ctx.putImageData(imageData, 0, 0);
 };
 
-customLayerDemo();
+document.onreadystatechange = () => {
+  if (document.readyState == 'complete') {
+    customLayerDemo();
+  }
+}

--- a/custom-layer/package.json
+++ b/custom-layer/package.json
@@ -25,28 +25,5 @@
     "cross-env": "^5.1.6",
     "parcel-bundler": "~1.10.3",
     "yalc": "~1.0.0-pre.22"
-  },
-  "babel": {
-    "presets": [
-      [
-        "env",
-        {
-          "modules": false,
-          "targets": {
-            "browsers": [
-              "> 1%",
-              "last 3 versions",
-              "ie >= 9",
-              "ios >= 8",
-              "android >= 4.2"
-            ]
-          },
-          "useBuiltIns": false
-        }
-      ]
-    ],
-    "plugins": [
-      "transform-runtime"
-    ]
   }
 }


### PR DESCRIPTION
Wait for document.readyState == 'complete' before inspecting image contents.

Also moves babel configuration out of package.json and into a .babelrc file, to match the other examples.  