### PR TITLE
Closure not needed for `let` variable

### DIFF
--- a/mobilenet/index.js
+++ b/mobilenet/index.js
@@ -172,8 +172,6 @@ filesElement.addEventListener('change', evt => {
       continue;
     }
     let reader = new FileReader();
-    const idx = i;
-    // Closure to capture the file information.
     reader.onload = e => {
       // Fill the image & call predict.
       let img = document.createElement('img');


### PR DESCRIPTION
`idx` is not required. `i` is already in a closure as `let` is used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/336)
<!-- Reviewable:end -->
