### PR TITLE
[DOC] Add hosted tensorboard summaries (tensorboard.dev links) to README files

### DIFF
--- a/date-conversion-attention/README.md
+++ b/date-conversion-attention/README.md
@@ -54,7 +54,7 @@ advantanges:
 ![date-conversion attention model training: TensorBoard example](./date-conversion-attention-tensorboard-example.png)
 
 A detailed tensorboard training log is hosted and viewable at this
-[tensorboard.dev link](https://tensorboard.dev/experiment/CqhZhKlNSgimJbnIwvbmnw/#scalars).
+[TensorBoard.dev link](https://tensorboard.dev/experiment/CqhZhKlNSgimJbnIwvbmnw/#scalars).
 
 To do this in this example, add the flag `--logDir` to the `yarn train`
 command, followed by the directory to which you want the logs to

--- a/date-conversion-attention/README.md
+++ b/date-conversion-attention/README.md
@@ -53,6 +53,9 @@ advantanges:
 
 ![date-conversion attention model training: TensorBoard example](./date-conversion-attention-tensorboard-example.png)
 
+A detailed tensorboard training log is hosted and viewable at this
+[tensorboard.dev link](https://tensorboard.dev/experiment/CqhZhKlNSgimJbnIwvbmnw/#scalars).
+
 To do this in this example, add the flag `--logDir` to the `yarn train`
 command, followed by the directory to which you want the logs to
 be written, e.g.,

--- a/mnist-acgan/README.md
+++ b/mnist-acgan/README.md
@@ -72,7 +72,7 @@ advantanges:
 ![MNIST ACGAN Training: TensorBoard Example](./mnist-acgan-tensorboard-example.png)
 
 Detailed loss profiles are hosted and viewable at this
-[tensorboard.dev link](https://tensorboard.dev/experiment/iBcGONlbQbmVyNd8H6unJg/#scalars).
+[TensorBoard.dev link](https://tensorboard.dev/experiment/iBcGONlbQbmVyNd8H6unJg/#scalars).
 
 To do this in this example, add the flag `--logDir` to the `yarn train`
 command, followed by the directory to which you want the logs to

--- a/mnist-acgan/README.md
+++ b/mnist-acgan/README.md
@@ -21,7 +21,7 @@ This example of TensorFlow.js runs simultaneously in two different environments:
  - Demonstration of generation in the browser. The demo webpage will load
    the checkpoints saved from the training process and use it to generate
    fake MNIST images in the browser.
- 
+
 ## How to use this example
 
 This example can be used in two ways:
@@ -32,7 +32,7 @@ This example can be used in two ways:
    the web.
 
 For approach 1, you can start the training by:
- 
+
 ```sh
 yarn
 yarn train
@@ -71,6 +71,9 @@ advantanges:
 
 ![MNIST ACGAN Training: TensorBoard Example](./mnist-acgan-tensorboard-example.png)
 
+Detailed loss profiles are hosted and viewable at this
+[tensorboard.dev link](https://tensorboard.dev/experiment/iBcGONlbQbmVyNd8H6unJg/#scalars).
+
 To do this in this example, add the flag `--logDir` to the `yarn train`
 command, followed by the directory to which you want the logs to
 be written, e.g.,
@@ -93,9 +96,9 @@ navigate to the URL to view the loss curves in the Scalar dashboard of
 TensorBoard.
 
 ### Running Generator demo in the Browser
- 
+
 To start the demo in the browser, do in a separate terminal:
- 
+
 ```sh
 yarn
 yarn watch
@@ -109,13 +112,13 @@ been started), the user may still click the "Load Hosted Model" button
 to load a remotely-hosted generator.
 
 ### Training the model on CUDA GPUs using tfjs-node-gpu
- 
+
 It is recommended to use tfjs-node-gpu to train the model on a CUDA-enabled GPU,
 as the convolution heavy operations run several times faster a GPU than on the
 CPU with tfjs-node.
 
 By default, the [training script](./gan.js) runs on the CPU using tfjs-node. To
-run it on the GPU, repace the line 
+run it on the GPU, repace the line
 
 ```js
 require('@tensorflow/tfjs-node');

--- a/sentiment/README.md
+++ b/sentiment/README.md
@@ -90,19 +90,17 @@ Other arguments of the `yarn train` command include:
   tensorboard (by default: http://localhost:6006) to view the loss and accuracy
   curves.
 
-  The links below point to hosted TensorBoard training los for various model
+  The links below point to TensorBoard.dev training los for various model
   types:
 
-  - [`multihot`](https://tensorboard.dev/experiment/8Ltk9awdQVeEdIqmZF6UZg)
-  - [`flatten`](https://tensorboard.dev/experiment/8dYnJmlDRe21vNJrHYB3Yg)
-  - [`cnn`](https://tensorboard.dev/experiment/pP6s7BozQESnbXXQy1rJtQ)
-  - [`simpleRNN`](https://tensorboard.dev/experiment/zl266tMbRuKAr4PBsny8XQ)
-  - [`lstm`](https://tensorboard.dev/experiment/VHKxx8OnSze7glfzqCXi9A)
-  - [`bidirectionalLSTM`](https://tensorboard.dev/experiment/osVo6vAaR0SZWzUvElz5ow)
-
+  - [`multihot`](https://tensorboard.dev/experiment/8Ltk9awdQVeEdIqmZF6UZg/#scalars)
+  - [`flatten`](https://tensorboard.dev/experiment/8dYnJmlDRe21vNJrHYB3Yg/#scalars)
+  - [`cnn`](https://tensorboard.dev/experiment/pP6s7BozQESnbXXQy1rJtQ/#scalars)
+  - [`simpleRNN`](https://tensorboard.dev/experiment/zl266tMbRuKAr4PBsny8XQ/#scalars)
+  - [`lstm`](https://tensorboard.dev/experiment/VHKxx8OnSze7glfzqCXi9A/#scalars)
+  - [`bidirectionalLSTM`](https://tensorboard.dev/experiment/osVo6vAaR0SZWzUvElz5ow/#scalars)
 
 The detailed code for training are in the file [train.js](./train.js).
-
 
 ### Visualizing the word embeddings in embedding projector
 

--- a/sentiment/README.md
+++ b/sentiment/README.md
@@ -90,6 +90,17 @@ Other arguments of the `yarn train` command include:
   tensorboard (by default: http://localhost:6006) to view the loss and accuracy
   curves.
 
+  The links below point to hosted TensorBoard training los for various model
+  types:
+
+  - [`multihot`](https://tensorboard.dev/experiment/8Ltk9awdQVeEdIqmZF6UZg)
+  - [`flatten`](https://tensorboard.dev/experiment/8dYnJmlDRe21vNJrHYB3Yg)
+  - [`cnn`](https://tensorboard.dev/experiment/pP6s7BozQESnbXXQy1rJtQ)
+  - [`simpleRNN`](https://tensorboard.dev/experiment/zl266tMbRuKAr4PBsny8XQ)
+  - [`lstm`](https://tensorboard.dev/experiment/VHKxx8OnSze7glfzqCXi9A)
+  - [`bidirectionalLSTM`](https://tensorboard.dev/experiment/osVo6vAaR0SZWzUvElz5ow)
+
+
 The detailed code for training are in the file [train.js](./train.js).
 
 

--- a/sentiment/README.md
+++ b/sentiment/README.md
@@ -90,7 +90,7 @@ Other arguments of the `yarn train` command include:
   tensorboard (by default: http://localhost:6006) to view the loss and accuracy
   curves.
 
-  The links below point to TensorBoard.dev training los for various model
+  The links below point to TensorBoard.dev training loss for various model
   types:
 
   - [`multihot`](https://tensorboard.dev/experiment/8Ltk9awdQVeEdIqmZF6UZg/#scalars)

--- a/snake-dqn/README.md
+++ b/snake-dqn/README.md
@@ -61,6 +61,9 @@ pip install tensorboard
 tensorboard --logdir /tmp/snake_logs
 ```
 
+A detailed TensorBoard training log is hosted and viewable at this
+[tensorboard.dev link](https://tensorboard.dev/experiment/tB9N57tkR4e1ZBo918GKZQ/#scalars).
+
 Once started, the tensorboard backend process will print an `http://` URL to the
 console. Open your browser and navigate to the URL to see the logged curves.
 

--- a/snake-dqn/README.md
+++ b/snake-dqn/README.md
@@ -62,7 +62,7 @@ tensorboard --logdir /tmp/snake_logs
 ```
 
 A detailed TensorBoard training log is hosted and viewable at this
-[tensorboard.dev link](https://tensorboard.dev/experiment/tB9N57tkR4e1ZBo918GKZQ/#scalars).
+[tensorboard.dev link](https://tensorboard.dev/experiment/TJFBWBx3T5WrFBs4Ar76Sw/#scalars).
 
 Once started, the tensorboard backend process will print an `http://` URL to the
 console. Open your browser and navigate to the URL to see the logged curves.

--- a/snake-dqn/README.md
+++ b/snake-dqn/README.md
@@ -62,7 +62,7 @@ tensorboard --logdir /tmp/snake_logs
 ```
 
 A detailed TensorBoard training log is hosted and viewable at this
-[tensorboard.dev link](https://tensorboard.dev/experiment/TJFBWBx3T5WrFBs4Ar76Sw/#scalars).
+[TensorBoard.dev link](https://tensorboard.dev/experiment/TJFBWBx3T5WrFBs4Ar76Sw/#scalars).
 
 Once started, the tensorboard backend process will print an `http://` URL to the
 console. Open your browser and navigate to the URL to see the logged curves.


### PR DESCRIPTION
Using permalinks from Hosted TensorBoard (tensorboard.dev).

tensorboard.dev links are added for the following examples:
- date-conversion-attention
- mnist-acgan
- sentiment
- snake-dqn

DOC

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/339)
<!-- Reviewable:end -->
