### PR TITLE
Enable using a custom text dataset in LSTM CLI

### DIFF
--- a/lstm-text-generation/README.md
+++ b/lstm-text-generation/README.md
@@ -62,7 +62,8 @@ yarn train shakespeare \
 
 - The first argument to `yarn train` (`shakespeare`) specifies what text corpus
   to train the model on. See the console output of `yarn train --help` for a set
-  of supported text data.
+  of supported text data. You can also provide the path to a file containing
+  your own text corpus.
 - The argument `--lstmLayerSize 128,128` specifies that the next-character
   prediction model should contain two LSTM layers stacked on top of each other,
   each with 128 units.

--- a/lstm-text-generation/gen_node.js
+++ b/lstm-text-generation/gen_node.js
@@ -97,7 +97,8 @@ async function main() {
   }
 
   // Load the model.
-  const model = await tf.loadModel(`file://${args.modelJSONPath}`);
+  const loadModel = tf.loadModel || tf.loadLayersModel;
+  const model = await loadModel(`file://${args.modelJSONPath}`);
 
   const sampleLen = model.inputs[0].shape[1];
 

--- a/lstm-text-generation/gen_node.js
+++ b/lstm-text-generation/gen_node.js
@@ -33,10 +33,11 @@ function parseArgs() {
   const parser = argparse.ArgumentParser({
     description: 'Train an lstm-text-generation model.'
   });
-  parser.addArgument('textDatasetName', {
+  parser.addArgument('textDatasetNameOrPath', {
     type: 'string',
-    choices: Object.keys(TEXT_DATA_URLS),
-    help: 'Name of the text dataset'
+    help: 'Name of the text dataset (one of ' +
+      Object.keys(TEXT_DATA_URLS).join(', ') +
+      ') or the path to a text file containing a custom dataset'
   });
   parser.addArgument('modelJSONPath', {
     type: 'string',
@@ -64,7 +65,24 @@ function parseArgs() {
     help: 'Step length: how many characters to skip between one example ' +
     'extracted from the text data to the next.'
   });
-  return parser.parseArgs();
+
+  const args = parser.parseArgs();
+
+  const isDataset = TEXT_DATA_URLS[args.textDatasetNameOrPath];
+  const isFile = fs.existsSync(args.textDatasetNameOrPath)
+    && fs.statSync(args.textDatasetNameOrPath).isFile();
+  if (isDataset) {
+    args.textDatasetName = args.textDatasetNameOrPath;
+    delete args.textDatasetNameOrPath;
+  } else if (isFile) {
+    args.textDatasetPath = args.textDatasetNameOrPath;
+    delete args.textDatasetNameOrPath;
+  } else {
+    parser.error('Argument should be one of ' +
+      Object.keys(TEXT_DATA_URLS).join(', ') +
+      ' or the path to a dataset text file');
+  }
+  return args;
 }
 
 async function main() {
@@ -84,9 +102,12 @@ async function main() {
   const sampleLen = model.inputs[0].shape[1];
 
   // Create the text data object.
-  const textDataURL = TEXT_DATA_URLS[args.textDatasetName].url;
-  const localTextDataPath = path.join(os.tmpdir(), path.basename(textDataURL));
-  await maybeDownload(textDataURL, localTextDataPath);
+  let localTextDataPath = args.textDatasetPath;
+  if (args.textDatasetName) {
+    const textDataURL = TEXT_DATA_URLS[args.textDatasetName].url;
+    localTextDataPath = path.join(os.tmpdir(), path.basename(textDataURL));
+    await maybeDownload(textDataURL, localTextDataPath);
+  }
   const text = fs.readFileSync(localTextDataPath, {encoding: 'utf-8'});
   const textData = new TextData('text-data', text, sampleLen, args.sampleStep);
 


### PR DESCRIPTION
Currently the LSTM TensorflowJS example only supports a fixed set of preset text datasets. To enable users to easily experiment with their own datasets, this pull request enables passing arbitrary local text files to the training and generation scripts.

Additionally, I observed that the use of `tf.loadModel` in `gen_node.js` crashes since the method was renamed to `tf.loadLayersModel` in the tfjs 1.0 release. As such, this pull request also updates the model loading code to handle both the old and new method names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/350)
<!-- Reviewable:end -->
