### PR TITLE
Update gan.js

### DIFF
--- a/mnist-acgan/gan.js
+++ b/mnist-acgan/gan.js
@@ -265,7 +265,7 @@ function buildCombinedModel(latentSize, generator, discriminator, optimizer) {
 
 // "Soft" one used for training the combined ACGAN model.
 // This is an important trick in training GANs.
-const SOFT_ONE = tf.tensor1d([.95]);
+const SOFT_ONE = tf.scalar(0.95);
 
 /**
  * Train the discriminator for one step.

--- a/mnist-acgan/gan.js
+++ b/mnist-acgan/gan.js
@@ -265,7 +265,7 @@ function buildCombinedModel(latentSize, generator, discriminator, optimizer) {
 
 // "Soft" one used for training the combined ACGAN model.
 // This is an important trick in training GANs.
-const SOFT_ONE = 0.95;
+const SOFT_ONE = tf.tensor1d([.95]);
 
 /**
  * Train the discriminator for one step.


### PR DESCRIPTION
SOFT_ONE should be tensor, not a number.

This variable is used incorrectly in given circumstances. For example **_tf.ones([batchSize, 1]).mul(SOFT_ONE)_**

This is based on [following documentation](https://js.tensorflow.org/api/latest/#mul) which states that parameter of 'mul' method is tensor - not a number.

Incorrect usage also throws following exception: _**Argument 'b' passed to 'mul' must be a Tensor, but got number.**_

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/351)
<!-- Reviewable:end -->
