### PR TITLE
[Interactive visualizers] Add image classifier support

### DIFF
--- a/interactive-visualizers/README.md
+++ b/interactive-visualizers/README.md
@@ -3,8 +3,18 @@
 TensorFlow.js-powered Interactive Model Visualizers for standard perception
 tasks embeddable anywhere in the web.
 
-Supported tasks: * Image Classification * Object Detection (WIP) * Image
-Segmentation (WIP)
+Supported tasks:
+
+*   Image Classification
+*   Object Detection (WIP)
+*   Image Segmentation (WIP)
+
+The Interactive Visualizer supports any model coming with a metadata JSON file
+formatted following the supported tasks standards.
+
+NOTE: standards definition is WIP. Here's an example of such metadata for an
+image classifier model:
+https://storage.googleapis.com/tfhub-visualizers/google/aiy/vision/classifier/plants_V1/1/metadata.json.
 
 This project was generated with
 [Angular CLI](https://github.com/angular/angular-cli) version 10.1.3.

--- a/interactive-visualizers/README.md
+++ b/interactive-visualizers/README.md
@@ -10,7 +10,12 @@ Supported tasks:
 *   Image Segmentation (WIP)
 
 The Interactive Visualizer supports any model coming with a metadata JSON file
-formatted following the supported tasks standards.
+formatted following the supported tasks standards. This metadata file is passed
+at runtime to the visualizer as URL query parameter (e.g.
+`https://visualizerHostedUrl/?modelMetadataUrl=https://myModelMetadataUrl/metadata.json`).
+
+The visualizer will then load its UI and behave according to the task defined by
+the model metadata.
 
 NOTE: standards definition is WIP. Here's an example of such metadata for an
 image classifier model:

--- a/interactive-visualizers/README.md
+++ b/interactive-visualizers/README.md
@@ -1,19 +1,29 @@
 # TensorFlow.js Interactive Model Visualizers
 
-TensorFlow.js-powered Interactive Model Visualizers for standard perception tasks
-embeddable anywhere in the web.
+TensorFlow.js-powered Interactive Model Visualizers for standard perception
+tasks embeddable anywhere in the web.
 
-Supported tasks:
-* Image Classification (WIP)
-* Object Detection (WIP)
-* Image Segmentation (WIP)
+Supported tasks: * Image Classification * Object Detection (WIP) * Image
+Segmentation (WIP)
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 10.1.3.
+This project was generated with
+[Angular CLI](https://github.com/angular/angular-cli) version 10.1.3.
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app
+will automatically reload if you change any of the source files.
 
 ## Build
 
-Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `--prod` flag for a production build.
+Run `ng build` to build the project. The build artifacts will be stored in the
+`dist/` directory. Use the `--prod` flag for a production build.
+
+## Test
+
+Run `ng test` to run the tests.
+[Karma](https://karma-runner.github.io/latest/index.html) is providing the
+testing environment, and [Jasmine](https://jasmine.github.io/) is used for unit
+testing.
+
+Additionally run `ng lint` to check for the linter warnings/errors.

--- a/interactive-visualizers/karma.conf.js
+++ b/interactive-visualizers/karma.conf.js
@@ -18,22 +18,23 @@
 // Karma configuration file, see link for more information
 // https://karma-runner.github.io/1.0/config/configuration-file.html
 
-module.exports = function (config) {
+module.exports = function(config) {
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
-      require('karma-jasmine'),
-      require('karma-chrome-launcher'),
+      require('karma-jasmine'), require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),
       require('@angular-devkit/build-angular/plugins/karma')
     ],
     client: {
-      clearContext: false // leave Jasmine Spec Runner output visible in browser
+      clearContext:
+          false  // leave Jasmine Spec Runner output visible in browser
     },
     coverageIstanbulReporter: {
-      dir: require('path').join(__dirname, './coverage/interactive-visualizers'),
+      dir:
+          require('path').join(__dirname, './coverage/interactive-visualizers'),
       reports: ['html', 'lcovonly', 'text-summary'],
       fixWebpackSourcePaths: true
     },

--- a/interactive-visualizers/src/app/app.component.html
+++ b/interactive-visualizers/src/app/app.component.html
@@ -25,11 +25,28 @@ limitations under the License.
            (dragover)="dragOver(event)"
            (dragleave)="dragLeave()"
            (drop)="dragDrop(event)">
+        <ng-container *ngIf="queryImageDataURL != null">
+          <div class="QueryCanvasOverlayContainer">
+            <!-- Spot for overlaying a canvas on top of the query image. -->
+            <canvas class="QueryCanvasOverlay">
+            </canvas>
+          </div>
+          <div class="QueryCanvasOverlayContainer">
+            <div class="QueryHintsContainer">
+            </div>
+          </div>
+          <div class="QueryImageContainer">
+            <img src="{{ queryImageDataURL }}"
+                 class="QueryImage"
+                 alt="">
+          </div>
+        </ng-container>
       </div>
 
       <!-- Render test data once available -->
       <div class="TestImages" *ngIf="testImages.length > 0">
-        <div class="TestImageContainer" *ngFor="let testImage of testImages">
+        <div class="TestImageContainer" *ngFor="let testImage of testImages"
+             (click)="testImageSelected(testImage.imageUrl)">
           <img src="{{ testImage.thumbnailUrl }}" class="TestImage">
         </div>
       </div>
@@ -42,8 +59,38 @@ limitations under the License.
       <div class="InputSection">
         <ng-container *ngTemplateOutlet="inputSection"></ng-container>
       </div>
-      <div class="ResultsSection"
-           id="results-section">
+      <div class="ResultsSection">
+        <!-- Case of classifier results -->
+        <div class="Results" *ngIf="classifierResults != null">
+          <div class="ResultTitle">
+            Results:
+          </div>
+          <ng-container *ngIf="resultsKeyName != null && resultsValueName != null">
+            <div class="ResultSubtitle">
+              <div class="ResultSubtitleType">
+                {{ resultsKeyName }}
+              </div>
+              <div class="ResultSubtitleUnit">
+                {{ resultsValueName }}
+              </div>
+            </div>
+          </ng-container>
+          <div class="ResultList">
+            <div class="ResultBarBackground"></div>
+            <div class="ClassifierResult" *ngFor="let result of classifierResults">
+              <div class="ClassifierResultDisplayName">
+                {{ result.displayName }}
+              </div>
+              <div class="ClassifierResultScorePercent">
+                {{ result.score | number:'1.1-3' }}
+              </div>
+              <div class="ResultBarBackground"></div>
+              <div class="ResultBarForeground"
+                   style="width: {{ 100 * result.score | number }}%">
+              </div>
+            </div>
+          </div>
+        </div>
       </div>
       <div class="RightFooter">
         <div class="RightFooterAction"

--- a/interactive-visualizers/src/app/app.component.scss
+++ b/interactive-visualizers/src/app/app.component.scss
@@ -105,6 +105,87 @@ $XXSMALL_FONT_SIZE: 12px;
   font-weight: 600;
 }
 
+/* Query image */
+
+.QueryImageTitle {
+  font-size: $MEDIUM_FONT_SIZE;
+  padding-bottom: 20px;
+}
+
+.QueryImageContainer {
+  display: inline-flex;
+  flex: 1 1 auto;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  margin: 0 auto;
+  position: relative;
+  width: 100%;
+}
+
+.QueryCanvasOverlayContainer {
+  display: inline-flex;
+  flex-direction: column;
+  height: 100%;
+  justify-content: center;
+  margin: 0 auto;
+  position: absolute;
+  width: 100%;
+}
+
+.QueryCanvasOverlay {
+  display: block;
+  margin: 0 auto;
+  max-height: 100%;
+  max-width: 100%;
+  position: relative;
+  z-index: 1;
+}
+
+.QueryHintsContainer {
+  height: 100%;
+  margin: 0 auto;
+  position: relative;
+  width: 100%;
+}
+
+.QueryHint {
+  border-radius: 100%;
+  color: $PRIMARY_BACKGROUND_COLOR;
+  display: block;
+  height: 20px;
+  position: absolute;
+  width: 20px;
+  z-index: 20;
+}
+
+.QueryHint:hover {
+  cursor: pointer;
+  height: 30px;
+  margin-left: -5px;
+  margin-top: -5px;
+  width: 30px;
+  z-index: 21;
+}
+
+.QueryHint:hover > .QueryHintValue {
+  margin-top: 7px;
+}
+
+.QueryHintValue {
+  font-size: $XXSMALL_FONT_SIZE;
+  margin-top: 2px;
+  text-align: center;
+}
+
+.QueryImage {
+  display: block;
+  margin: 0 auto;
+  max-height: 100%;
+  max-width: 100%;
+  position: relative;
+}
+
 /* Test images */
 
 .TestImageContainer {
@@ -159,14 +240,91 @@ $XXSMALL_FONT_SIZE: 12px;
   vertical-align: top;
 }
 
+/* Results section */
+
+.Results {
+  height: 100%;
+  width: 100%;
+}
+
+.ResultTitle {
+  color: $SECONDARY_TEXT_COLOR;
+  font-size: $MEDIUM_FONT_SIZE;
+  font-weight: 600;
+  height: 30px;
+}
+
+.ResultSubtitle {
+  color: $SECONDARY_TEXT_COLOR;
+  font-size: $XXSMALL_FONT_SIZE;
+  height: 15px;
+  margin-top: 10px;
+}
+
+.ResultSubtitleType {
+  display: inline-block;
+  float: left;
+}
+
+.ResultSubtitleUnit {
+  display: inline-block;
+  float: right;
+}
+
+.ResultList {
+  height: calc(100% - 63px);
+  margin-top: 8px;
+  overflow-y: scroll;
+  -webkit-mask-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0,0,0,1)), to(rgba(0,0,0,0.8)));
+  width: 100%;
+}
+
+.ResultBarBackground {
+  background-color: $BORDER_COLOR;
+  height: 2px;
+  margin-top: 5px;
+  width: calc(100% - 2px);
+}
+
+.ResultBarForeground {
+  background-color: $VALUE_COLOR;
+  height: 2px;
+  margin-top: -2px;
+  position: absolute;
+  width: calc(100% - 2px);
+}
+
+/* Classifier results */
+
+.ClassifierResult {
+  font-size: $SMALL_FONT_SIZE;
+  margin-top: 12px;
+  position: relative;
+}
+
+.ClassifierResultDisplayName {
+  display: inline-block;
+  max-width: calc(100% - 55px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.ClassifierResultScorePercent {
+  color: $VALUE_COLOR;
+  display: inline-block;
+  float: right;
+  vertical-align: top;
+}
+
 /* Right Footer */
 
 .RightFooterAction {
-  color: PRIMARY_TEXT_COLOR;
+  color: $PRIMARY_TEXT_COLOR;
   cursor: pointer;
   display: inline-block;
   float: right;
-  font-size: XSMALL_FONT_SIZE;
+  font-size: $XSMALL_FONT_SIZE;
   font-weight: 600;
   margin-top: 25px;
   vertical-align: top;

--- a/interactive-visualizers/src/app/app.component.ts
+++ b/interactive-visualizers/src/app/app.component.ts
@@ -24,6 +24,9 @@ const DOWNLOAD_MESSAGE =
 const NO_MODEL_METADATA_ERROR_MESSAGE =
     'No model metadata URL provided. The visualizer could not start';
 
+// Constants.
+const MAX_NB_RESULTS = 100;
+
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -38,13 +41,19 @@ export class AppComponent implements OnInit {
   modelMetadata: any|null = null;
   modelType: string|null = null;
   model: tf.GraphModel|null = null;
-  labelmap: string[] = [];
+  labelmap: string[]|null = null;
   defaultScoreThreshold = 0.0;
 
   // Test data related variables.
   testImagesIndexUrl: string|null = null;
   testImages: Array<{imageUrl: string, thumbnailUrl: string}> = [];
   uploadedImages: string[] = [];
+  queryImageDataURL: string|null = null;
+
+  // Results variables.
+  resultsKeyName: string|null = null;
+  resultsValueName: string|null = null;
+  classifierResults: Array<{displayName: string, score: number}>|null = null;
 
   ngOnInit(): void {
     // Sanity checks on URL query parameters.
@@ -114,5 +123,154 @@ export class AppComponent implements OnInit {
   getTestImagesUrlPrefix(): string {
     const imageIndexFileName = this.testImagesIndexUrl.split('/').pop();
     return this.testImagesIndexUrl.split(imageIndexFileName)[0];
+  }
+
+  /**
+   * On click on a test image.
+   */
+  async testImageSelected(imageUrl: string): Promise<void> {
+    const response = await fetch(imageUrl);
+    const blob = await response.blob();
+    const reader = new FileReader();
+    reader.onload = () => {
+      let imageDataURL: string = reader.result as string;
+      // If MIME is unknown, replace it to 'image/jpg' as an attempt.
+      imageDataURL =
+          imageDataURL.replace('application/octet-stream', 'image/jpg');
+      this.handleInputImage(imageDataURL);
+    };
+    reader.readAsDataURL(blob);
+  }
+
+  /**
+   * Handles an input image as data URL. Displays it in the query element, and
+   * sends it for inference to the right handler depending on the model type.
+   */
+  async handleInputImage(imageDataURL: string): Promise<void> {
+    this.queryImageDataURL = imageDataURL;
+    const image = new Image();
+    image.onload = async () => {
+      switch (this.modelType) {
+        case 'classifier':
+          this.classifierResults = await this.runImageClassifier(image);
+          this.resultsKeyName = 'Type';
+          this.resultsValueName = 'Score';
+          break;
+        default:
+          console.error(
+              `The model type \`${this.modelType}\ isn't currently supported.`);
+      }
+    };
+    image.src = imageDataURL;
+  }
+
+  /**
+   * Prepare an input image by converting it to tf.Tensor and resizing it
+   * according to the expected model input.
+   */
+  prepareImageInput(image: HTMLImageElement, inputTensorMetadata: {
+    shape: number[]
+  }): tf.Tensor {
+    let imageTensor = tf.browser.fromPixels(image, /* numChannels= */ 3);
+
+    // Resize the query image according to the model input shape.
+    imageTensor = tf.image.resizeBilinear(
+        imageTensor,
+        [inputTensorMetadata.shape[1], inputTensorMetadata.shape[2]], false);
+
+    // Map to the correct input shape, range and type. The models expect float
+    // inputs in the range [0, 1].
+    imageTensor = imageTensor.toFloat().div(255).expandDims(0);
+
+    return imageTensor;
+  }
+
+  /**
+   * Fetches and parses the labelmap. If IDs are provided, they are used.
+   * Otherwise list indices are used as IDs.
+   */
+  async fetchLabelmap(labelmapName: string): Promise<void> {
+    const labelmapUrl = this.getAssetsUrlPrefix() + labelmapName;
+    const labelmapResponse = await fetch(labelmapUrl);
+    const labelmapJson = await labelmapResponse.json();
+    let maxId = labelmapJson.item.length - 1;
+    for (const item of labelmapJson.item) {
+      if (item.id && item.id > maxId) {
+        maxId = item.id;
+      }
+    }
+    const labelmap = [];
+    for (let i = 0; i <= maxId; ++i) {
+      labelmap.push('unknown');
+    }
+    for (let i = 0; i < labelmapJson.item.length; ++i) {
+      const item = labelmapJson.item[i];
+      let displayName = 'unknown';
+      if (item.name) {
+        displayName = item.name;
+      }
+      if (item.display_name) {
+        displayName = item.display_name;
+      }
+      if (item.id) {
+        labelmap[item.id] = displayName;
+      } else {
+        labelmap[i] = displayName;
+      }
+    }
+    this.labelmap = labelmap;
+  }
+
+  /**
+   * Run the model in case of image classification, and return classifier
+   * results.
+   */
+  async runImageClassifier(image: HTMLImageElement):
+      Promise<Array<{displayName: string, score: number}>> {
+    // Prepare inputs.
+    const inputTensorMetadata =
+        this.modelMetadata.tfjs_classifier_model_metadata.input_tensor_metadata;
+    const imageTensor = this.prepareImageInput(image, inputTensorMetadata);
+
+    // Execute the model.
+    const outputTensor: tf.Tensor =
+        await this.model.executeAsync(imageTensor) as tf.Tensor;
+    const predictions: number[] =
+        await outputTensor.squeeze().array() as number[];
+
+    // Fetch the labelmap and score thresholds, then assign labels to the
+    // prediction results.
+    const outputHeadMetadata = this.modelMetadata.tfjs_classifier_model_metadata
+                                   .output_head_metadata[0];
+    let scoreThreshold = 0.0;
+    if (outputHeadMetadata.score_threshold) {
+      scoreThreshold = outputHeadMetadata.score_threshold;
+    }
+    if (this.labelmap == null) {
+      await this.fetchLabelmap(outputHeadMetadata.labelmap_path);
+    }
+    let results = [];
+    for (let i = 0; i < predictions.length; i++) {
+      if (predictions[i] > scoreThreshold) {
+        results.push({
+          displayName: this.labelmap[i],
+          score: predictions[i],
+        });
+      }
+    }
+
+    // Sort remaining results.
+    results.sort((a, b) => {
+      if (a.score > b.score) {
+        return -1;
+      }
+      return 1;
+    });
+
+    // Keep a maximum of MAX_NB_RESULTS for the UI.
+    if (results.length > MAX_NB_RESULTS) {
+      results = results.slice(0, MAX_NB_RESULTS);
+    }
+    return results;
   }
 }


### PR DESCRIPTION
Adds support for the following flow:

1. User clicks on one of the proposed test images
2. The image classifier runs on the image
3. Outputs are post-processed, then displayed in the UI

Screnshot:
![AgGW96GpspKBCft](https://user-images.githubusercontent.com/11316499/95910544-87d8e880-0da0-11eb-81c8-448cf8dccb7c.png)

Also adds relevant unit tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/363)
<!-- Reviewable:end -->
