### PR TITLE
[Interactive visualizers] Add image segmenter support

### DIFF
--- a/interactive-visualizers/README.md
+++ b/interactive-visualizers/README.md
@@ -6,8 +6,8 @@ tasks embeddable anywhere in the web.
 Supported tasks:
 
 *   Image Classification
-*   Object Detection (WIP)
-*   Image Segmentation (WIP)
+*   Object Detection
+*   Image Segmentation
 
 The Interactive Visualizer supports any model coming with a metadata JSON file
 formatted following the supported tasks standards. This metadata file is passed

--- a/interactive-visualizers/src/app/app.component.html
+++ b/interactive-visualizers/src/app/app.component.html
@@ -30,8 +30,8 @@ limitations under the License.
             <!-- Spot for overlaying a canvas on top of the query image -->
             <canvas class="QueryCanvasOverlay"
                     id="query-canvas-overlay"
-                    (click)="detectorResultLeft()"
-                    (mouseout)="detectorResultLeft()">
+                    (click)="canvasOverlayLeft()"
+                    (mouseout)="canvasOverlayLeft()">
             </canvas>
           </div>
           <div class="QueryCanvasOverlayContainer">
@@ -82,31 +82,8 @@ limitations under the License.
         </div>
       </div>
 
-      <!-- Left footer -->
-      <div class="LeftFooter">
-        <img *ngIf="publisherThumbnailUrl != null"
-             class="LeftFooterPublisherThumbnailUrl"
-             src="{{ publisherThumbnailUrl }}"
-             alt="">
-        <div *ngIf="publisherName != null"
-             class="LeftFooterPublisherNameContainer">
-          <div class="LeftFooterPublisherNameHeader">
-            Published by:
-          </div>
-          <div class="LeftFooterPublisherNameText">
-            {{ publisherName }}
-          </div>
-        </div>
-        <a class="LeftFooterTermsOfService"
-           href="https://www.google.com/intl/en/policies/terms/"
-           target="_blank">
-          Terms of Service
-        </a>
-        <a class="LeftFooterPrivacyPolicy"
-           href="https://www.google.com/intl/en/policies/privacy/"
-           target="_blank">
-          Privacy Policy
-        </a>
+      <div class="LeftFooter"
+           id="left-footer-section">
       </div>
     </div>
     <div class="RightSide">
@@ -120,6 +97,9 @@ limitations under the License.
           </ng-container>
           <ng-container *ngIf="detectorResults != null">
             <ng-container *ngTemplateOutlet="detectorResultsTemplate"></ng-container>
+          </ng-container>
+          <ng-container *ngIf="segmenterPredictions != null">
+            <ng-container *ngTemplateOutlet="segmenterResultsTemplate"></ng-container>
           </ng-container>
         </div>
       </div>
@@ -173,6 +153,32 @@ limitations under the License.
       </div>
     </div>
   </div>
+</ng-template>
+
+<ng-template #segmenterResultsTemplate>
+  <ng-container *ngTemplateOutlet="resultsHeader"></ng-container>
+  <div class="ResultList">
+    <div class="ResultBarBackground"></div>
+    <div *ngFor="let label of segmenterLabelList"
+         class="SegmenterResult"
+         (mouseenter)="segmenterResultHovered(label.index)"
+         (mouseleave)="segmenterResultLeft()"
+         [ngClass]="{'ResultWithOpacity': hoveredSegmentationLabel != null && hoveredSegmentationLabel != label.index}">
+      <div class="SegmenterResultDisplayName"
+           style="color: {{ label.color }}">
+        {{ label.displayName }}
+      </div>
+      <div class="SegmenterResultScorePercent"
+           style="color: {{ label.color }}">
+        {{ label.frequencyPercent }}%
+      </div>
+      <div class="ResultBarBackground"></div>
+      <div class="ResultBarForeground"
+           style="width: {{ label.frequencyPercent | number }}%;
+                  background-color: {{ label.color }}">
+      </div>
+    </div>
+</div>
 </ng-template>
 
 <ng-template #detectorResultsTemplate>

--- a/interactive-visualizers/src/app/app.component.scss
+++ b/interactive-visualizers/src/app/app.component.scss
@@ -218,56 +218,6 @@ $XXSMALL_FONT_SIZE: 12px;
   width: calc(100% - 4px);
 }
 
-/* Left footer */
-
-.LeftFooterPublisherThumbnailUrl {
-  border-radius: 100%;
-  display: inline-block;
-  height: 50px;
-  width: 50px;
-}
-
-.LeftFooterPublisherNameContainer {
-  display: inline-block;
-  height: 100%;
-  margin-left: 12px;
-  vertical-align: top;
-}
-
-.LeftFooterPublisherNameHeader {
-  color: $SECONDARY_TEXT_COLOR;
-  font-size: $XXSMALL_FONT_SIZE;
-  height: 17px;
-  margin-top: 7px;
-}
-
-.LeftFooterPublisherNameText {
-  color: $PRIMARY_TEXT_COLOR;
-  font-size: $SMALL_FONT_SIZE;
-  height: 26px;
-}
-
-.LeftFooterPrivacyPolicy {
-  color: $PRIMARY_TEXT_COLOR;
-  cursor: pointer;
-  float: right;
-  font-size: $XXSMALL_FONT_SIZE;
-  margin-top: 28px;
-  padding-right: 8px;
-  text-decoration: none;
-}
-
-.LeftFooterTermsOfService {
-  border-left: solid 1px $BORDER_COLOR;
-  color: $PRIMARY_TEXT_COLOR;
-  cursor: pointer;
-  float: right;
-  font-size: $XXSMALL_FONT_SIZE;
-  margin-top: 28px;
-  padding-left: 8px;
-  text-decoration: none;
-}
-
 /* Input section */
 
 .DragAndDrop {
@@ -328,7 +278,7 @@ $XXSMALL_FONT_SIZE: 12px;
 .ResultList {
   height: calc(100% - 63px);
   margin-top: 8px;
-  overflow-y: scroll;
+  overflow-y: auto;
   -webkit-mask-image: -webkit-gradient(linear, left top, left bottom, from(rgba(0,0,0,1)), to(rgba(0,0,0,0.8)));
   width: 100%;
 }
@@ -346,6 +296,10 @@ $XXSMALL_FONT_SIZE: 12px;
   margin-top: -2px;
   position: absolute;
   width: calc(100% - 2px);
+}
+
+.ResultWithOpacity {
+  opacity: 0.5;
 }
 
 /* Classifier results */
@@ -368,6 +322,42 @@ $XXSMALL_FONT_SIZE: 12px;
   color: $VALUE_COLOR;
   display: inline-block;
   float: right;
+  vertical-align: top;
+}
+
+/* Segmenter results */
+
+.SegmenterResult {
+  cursor: pointer;
+  position: relative;
+}
+
+.SegmenterResultColor {
+  border-color: #424242;
+  border-radius: 100%;
+  display: inline-block;
+  height: 12px;
+  margin-right: 12px;
+  width: 12px;
+}
+
+.SegmenterResultDisplayName {
+  display: inline-block;
+  font-size: $SMALL_FONT_SIZE;
+  max-width: calc(100% - 70px);
+  overflow: hidden;
+  padding-bottom: 6px;
+  padding-top: 10px;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  white-space: nowrap;
+}
+
+.SegmenterResultScorePercent {
+  color: $VALUE_COLOR;
+  display: inline-block;
+  float: right;
+  padding-top: 10px;
   vertical-align: top;
 }
 

--- a/interactive-visualizers/src/app/app.component.ts
+++ b/interactive-visualizers/src/app/app.component.ts
@@ -583,7 +583,7 @@ export class AppComponent implements OnInit {
         await this.model.executeAsync(imageTensor, outputTensorName) as tf.Tensor;
     tf.dispose(imageTensor);
     const squeezedOutputTensor = outputTensor.squeeze();
-    tf.dispose(outputTensor)
+    tf.dispose(outputTensor);
     const predictions = await squeezedOutputTensor.array() as number[][];
     tf.dispose(squeezedOutputTensor);
 
@@ -594,9 +594,9 @@ export class AppComponent implements OnInit {
     // Generate labelmap if not found.
     if (this.labelmap == null) {
       let maxLabelIndex = 0;
-      for (let i = 0; i < predictions.length; ++i) {
-        for (let j = 0; j < predictions[i].length; ++j) {
-          maxLabelIndex = Math.max(maxLabelIndex, predictions[i][j]);
+      for (const predictionLine of predictions) {
+        for (const prediction of predictionLine) {
+          maxLabelIndex = Math.max(maxLabelIndex, prediction);
         }
       }
       this.labelmap = [];
@@ -607,23 +607,23 @@ export class AppComponent implements OnInit {
 
     // Compute label frequencies.
     const frequencies = new Array(this.labelmap.length).fill(0);
-    for (let i = 0; i < predictions.length; ++i) {
-      for (let j = 0; j < predictions[i].length; ++j) {
-        ++frequencies[predictions[i][j]];
+    for (const predictionLine of predictions) {
+        for (const prediction of predictionLine) {
+        ++frequencies[prediction];
       }
     }
 
     // Sort labels by decreasing area importance in the query image.
     const labelList = frequencies
-                          .map((frequency, index) => {
+                          .map((frequency, listIndex) => {
                             return {
-                              displayName: this.labelmap[index],
-                              index,
+                              displayName: this.labelmap[listIndex],
+                              index: listIndex,
                               frequencyPercent: Math.ceil(
                                   100 * frequency /
                                   (predictions.length * predictions[0].length)),
-                              color: `rgb(${255 * COLOR_LIST[index][0]}, ${255 *
-          COLOR_LIST[index][1]}, ${255 * COLOR_LIST[index][2]})`,
+                              color: `rgb(${255 * COLOR_LIST[listIndex][0]}, ${255 *
+          COLOR_LIST[listIndex][1]}, ${255 * COLOR_LIST[listIndex][2]})`,
                             };
                           })
                           .sort((a, b) => {
@@ -668,7 +668,7 @@ export class AppComponent implements OnInit {
                 height - 1,
                 Math.max(0, Math.round((event.clientY - rect.top) * scaleY)));
             const hoveredLabel = this.segmenterPredictions[y][x];
-            if (hoveredLabel != this.hoveredSegmentationLabel) {
+            if (hoveredLabel !== this.hoveredSegmentationLabel) {
               this.hoveredSegmentationLabel = hoveredLabel;
               this.fillSegmentationCanvas();
             }
@@ -684,7 +684,7 @@ export class AppComponent implements OnInit {
   /**
    * Fills a canvas with segmenter predictions overlaid on top of the query image.
    */
-  fillSegmentationCanvas() {
+  fillSegmentationCanvas(): void {
     const canvas = document.getElementById('query-canvas-overlay') as HTMLCanvasElement;
     canvas.style.cursor = 'pointer';
     const context = canvas.getContext('2d') as CanvasRenderingContext2D;
@@ -697,7 +697,7 @@ export class AppComponent implements OnInit {
         const labelIndex = this.segmenterPredictions[i][j];
         const currentPixel = 4 * (width * i + j);
         if (this.hoveredSegmentationLabel != null &&
-            labelIndex != this.hoveredSegmentationLabel) {
+            labelIndex !== this.hoveredSegmentationLabel) {
           data[currentPixel] = 0;
           data[currentPixel + 1] = 0;
           data[currentPixel + 2] = 0;

--- a/interactive-visualizers/src/app/app.component.ts
+++ b/interactive-visualizers/src/app/app.component.ts
@@ -176,8 +176,6 @@ export class AppComponent implements OnInit {
   title = 'interactive-visualizers';
 
   // Model related variables.
-  publisherThumbnailUrl: string|null = null;
-  publisherName: string|null = null;
   modelMetadataUrl: string|null = null;
   modelMetadata: any|null = null;
   modelType: string|null = null;
@@ -200,7 +198,9 @@ export class AppComponent implements OnInit {
   // Results variables.
   resultsKeyName: string|null = null;
   resultsValueName: string|null = null;
+  // Classifier specific variables.
   classifierResults: Array<{displayName: string, score: number}>|null = null;
+  // Detector specific variables.
   detectorResults: Array<{
     id: number,
     displayName: string,
@@ -221,6 +221,11 @@ export class AppComponent implements OnInit {
   hoveredDetectionLabel: number|null = null;
   hoveredDetectionResultLabel: number|null = null;
   hoveredDetectionResultId: number|null = null;
+  // Segmenter specific variables.
+  segmenterPredictions: number[][]|null = null;
+  segmenterLabelList: Array<{displayName: string, index: number,
+    frequencyPercent: number, color: string}>|null = null;
+  hoveredSegmentationLabel: number|null = null;
 
   ngOnInit(): void {
     // Sanity checks on URL query parameters.
@@ -229,12 +234,6 @@ export class AppComponent implements OnInit {
       throw new Error(NO_MODEL_METADATA_ERROR_MESSAGE);
     }
     const modelMetadataUrl = urlParams.get('modelMetadataUrl');
-    if (urlParams.has('publisherThumbnailUrl')) {
-      this.publisherThumbnailUrl = urlParams.get('publisherThumbnailUrl');
-    }
-    if (urlParams.has('publisherName')) {
-      this.publisherName = urlParams.get('publisherName');
-    }
 
     this.initApp(modelMetadataUrl);
   }
@@ -259,6 +258,8 @@ export class AppComponent implements OnInit {
       this.modelType = 'classifier';
     } else if (this.modelMetadata.tfjs_detector_model_metadata) {
       this.modelType = 'detector';
+    } else if (this.modelMetadata.tfjs_segmenter_model_metadata) {
+      this.modelType = 'segmenter';
     }
 
     // Fetch test data if any.
@@ -417,6 +418,9 @@ export class AppComponent implements OnInit {
         case 'detector':
           this.runImageDetector(image, index);
           break;
+        case 'segmenter':
+          this.runImageSegmenter(image, index);
+          break;
         default:
           console.error(
               `The model type \`${this.modelType}\ isn't currently supported.`);
@@ -558,6 +562,165 @@ export class AppComponent implements OnInit {
       this.resultsKeyName = 'Type';
       this.resultsValueName = 'Score';
     }
+  }
+
+  /**
+   * Run the model in case of image segmentation.
+   */
+  async runImageSegmenter(image: HTMLImageElement, index: number):
+      Promise<void> {
+    // Prepare inputs.
+    const inputTensorMetadata =
+        this.modelMetadata.tfjs_segmenter_model_metadata.input_tensor_metadata;
+    const imageTensor = this.prepareImageInput(image, inputTensorMetadata);
+
+    // Execute the model.
+    const outputHeadMetadata =
+        this.modelMetadata.tfjs_segmenter_model_metadata.output_head_metadata[0];
+    const outputTensorName =
+        outputHeadMetadata.semantic_predictions_tensor_name;
+    const outputTensor =
+        await this.model.executeAsync(imageTensor, outputTensorName) as tf.Tensor;
+    tf.dispose(imageTensor);
+    const squeezedOutputTensor = outputTensor.squeeze();
+    tf.dispose(outputTensor)
+    const predictions = await squeezedOutputTensor.array() as number[][];
+    tf.dispose(squeezedOutputTensor);
+
+    // Fetch the labelmap.
+    if (this.labelmap == null && outputHeadMetadata.labelmap_path != null) {
+      await this.fetchLabelmap(outputHeadMetadata.labelmap_path);
+    }
+    // Generate labelmap if not found.
+    if (this.labelmap == null) {
+      let maxLabelIndex = 0;
+      for (let i = 0; i < predictions.length; ++i) {
+        for (let j = 0; j < predictions[i].length; ++j) {
+          maxLabelIndex = Math.max(maxLabelIndex, predictions[i][j]);
+        }
+      }
+      this.labelmap = [];
+      for (let i = 0; i <= maxLabelIndex; ++i) {
+        this.labelmap.push(`Label ${i}`);
+      }
+    }
+
+    // Compute label frequencies.
+    const frequencies = new Array(this.labelmap.length).fill(0);
+    for (let i = 0; i < predictions.length; ++i) {
+      for (let j = 0; j < predictions[i].length; ++j) {
+        ++frequencies[predictions[i][j]];
+      }
+    }
+
+    // Sort labels by decreasing area importance in the query image.
+    const labelList = frequencies
+                          .map((frequency, index) => {
+                            return {
+                              displayName: this.labelmap[index],
+                              index,
+                              frequencyPercent: Math.ceil(
+                                  100 * frequency /
+                                  (predictions.length * predictions[0].length)),
+                              color: `rgb(${255 * COLOR_LIST[index][0]}, ${255 *
+          COLOR_LIST[index][1]}, ${255 * COLOR_LIST[index][2]})`,
+                            };
+                          })
+                          .sort((a, b) => {
+                            if (a.frequencyPercent > b.frequencyPercent) {
+                              return -1;
+                            }
+                            return 1;
+                          });
+
+    if (this.imageSelectedIndex === index) {
+      // Display results only for the last selected image (as the user may
+      // have switched selection while inference was running).
+      this.segmenterPredictions = predictions;
+      this.segmenterLabelList = labelList;
+      this.hoveredSegmentationLabel = null;
+      this.resultsKeyName = 'Type';
+      this.resultsValueName = 'Percentage of image area';
+
+      const imageHtmlElement = document.getElementById('query-image') as HTMLImageElement;
+      this.queryImageHeight = imageHtmlElement.offsetHeight;
+      this.queryImageWidth = imageHtmlElement.offsetWidth;
+      const width = predictions.length;
+      const height = predictions[0].length;
+      const canvas = document.getElementById('query-canvas-overlay') as HTMLCanvasElement;
+      canvas.style.height = `${this.queryImageHeight}px`;
+      canvas.style.width = `${this.queryImageWidth}px`;
+      canvas.width = width;
+      canvas.height = height;
+      const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+      context.fillRect(0, 0, width, height);
+      this.fillSegmentationCanvas();
+
+      canvas.addEventListener(
+          'mousemove', (event => {
+            const rect = canvas.getBoundingClientRect();
+            const scaleX = width / rect.width;
+            const scaleY = height / rect.height;
+            const x = Math.min(
+                width - 1,
+                Math.max(0, Math.round((event.clientX - rect.left) * scaleX)));
+            const y = Math.min(
+                height - 1,
+                Math.max(0, Math.round((event.clientY - rect.top) * scaleY)));
+            const hoveredLabel = this.segmenterPredictions[y][x];
+            if (hoveredLabel != this.hoveredSegmentationLabel) {
+              this.hoveredSegmentationLabel = hoveredLabel;
+              this.fillSegmentationCanvas();
+            }
+          }));
+
+      canvas.addEventListener('mouseout', (event => {
+                                this.hoveredSegmentationLabel = null;
+                                this.fillSegmentationCanvas();
+                              }));
+    }
+  }
+
+  /**
+   * Fills a canvas with segmenter predictions overlaid on top of the query image.
+   */
+  fillSegmentationCanvas() {
+    const canvas = document.getElementById('query-canvas-overlay') as HTMLCanvasElement;
+    canvas.style.cursor = 'pointer';
+    const context = canvas.getContext('2d') as CanvasRenderingContext2D;
+    const height = this.segmenterPredictions.length;
+    const width = this.segmenterPredictions[0].length;
+    const imageData = context.getImageData(0, 0, width, height);
+    const data = imageData.data;
+    for (let i = 0; i < height; ++i) {
+      for (let j = 0; j < width; ++j) {
+        const labelIndex = this.segmenterPredictions[i][j];
+        const currentPixel = 4 * (width * i + j);
+        if (this.hoveredSegmentationLabel != null &&
+            labelIndex != this.hoveredSegmentationLabel) {
+          data[currentPixel] = 0;
+          data[currentPixel + 1] = 0;
+          data[currentPixel + 2] = 0;
+          data[currentPixel + 3] = 0;  // Fully transparent.
+        } else {
+          data[currentPixel] = 255 * COLOR_LIST[labelIndex][0];
+          data[currentPixel + 1] = 255 * COLOR_LIST[labelIndex][1];
+          data[currentPixel + 2] = 255 * COLOR_LIST[labelIndex][2];
+          data[currentPixel + 3] = 150;
+        }
+      }
+    }
+    context.putImageData(imageData, 0, 0);
+  }
+
+  segmenterResultHovered(index: number): void {
+    this.hoveredSegmentationLabel = index;
+    this.fillSegmentationCanvas();
+  }
+
+  segmenterResultLeft(): void {
+    this.hoveredSegmentationLabel = null;
+    this.fillSegmentationCanvas();
   }
 
   /**
@@ -810,10 +973,12 @@ export class AppComponent implements OnInit {
   }
 
   /** When leaving a detector result or label hover. */
-  detectorResultLeft(): void {
-    this.hoveredDetectionResultLabel = null;
-    this.hoveredDetectionResultId = null;
-    this.removeOverlayedCanvas();
+  canvasOverlayLeft(): void {
+    if (this.detectorResults != null) {
+      this.hoveredDetectionResultLabel = null;
+      this.hoveredDetectionResultId = null;
+      this.removeOverlayedCanvas();
+    }
   }
 
   /** On hover on a specific detector result. */


### PR DESCRIPTION
This adds support for visualizing image segmenter.

Demo: 
![demo_seg](https://user-images.githubusercontent.com/11316499/97897676-1ce35780-1d37-11eb-9c7d-a082cc681030.gif)

The results are grouped by labels on the right side, and ordered by percent area of the query image. A segmentation mask is overlaid on top of the query image.

The behaviors are as follows:
* on result label hover: the related region gets highlighted
* on a region hover: same thing + label highlight

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/374)
<!-- Reviewable:end -->
