### PR TITLE
Support back camera in pose-detection tfjs-react-native example app

### DIFF
--- a/react-native/pose-detection/App.tsx
+++ b/react-native/pose-detection/App.tsx
@@ -49,7 +49,9 @@ export default function App() {
   const [fps, setFps] = useState(0);
   const [orientation, setOrientation] =
     useState<ScreenOrientation.Orientation>();
-  const [cameraType, setCameraType] = useState<CameraType>(CameraType.front);
+  const [cameraType, setCameraType] = useState<CameraType>(
+    Camera.Constants.Type.front
+  );
 
   useEffect(() => {
     async function prepare() {
@@ -123,8 +125,9 @@ export default function App() {
       const keypoints = poses[0].keypoints
         .filter((k) => (k.score ?? 0) > MIN_KEYPOINT_SCORE)
         .map((k) => {
-          // Flip horizontally on android.
-          const x = IS_ANDROID ? OUTPUT_TENSOR_WIDTH - k.x : k.x;
+          // Flip horizontally on android or when using back camera on iOS.
+          const flipX = IS_ANDROID || cameraType === Camera.Constants.Type.back;
+          const x = flipX ? OUTPUT_TENSOR_WIDTH - k.x : k.x;
           const y = k.y;
           const cx =
             (x / getOutputTensorWidth()) *
@@ -166,17 +169,18 @@ export default function App() {
         onTouchEnd={handleSwitchCameraType}
       >
         <Text>
-          Switch to {cameraType === CameraType.front ? 'back' : 'front'} camera
+          Switch to{' '}
+          {cameraType === Camera.Constants.Type.front ? 'back' : 'front'} camera
         </Text>
       </View>
     );
   };
 
   const handleSwitchCameraType = () => {
-    if (cameraType === CameraType.front) {
-      setCameraType(CameraType.back);
+    if (cameraType === Camera.Constants.Type.front) {
+      setCameraType(Camera.Constants.Type.back);
     } else {
-      setCameraType(CameraType.front);
+      setCameraType(Camera.Constants.Type.front);
     }
   };
 
@@ -219,9 +223,9 @@ export default function App() {
       case ScreenOrientation.Orientation.PORTRAIT_DOWN:
         return 180;
       case ScreenOrientation.Orientation.LANDSCAPE_LEFT:
-        return 270;
+        return cameraType === Camera.Constants.Type.front ? 270 : 90;
       case ScreenOrientation.Orientation.LANDSCAPE_RIGHT:
-        return 90;
+        return cameraType === Camera.Constants.Type.front ? 90 : 270;
       default:
         return 0;
     }

--- a/react-native/pose-detection/App.tsx
+++ b/react-native/pose-detection/App.tsx
@@ -127,7 +127,7 @@ export default function App() {
         .map((k) => {
           // Flip horizontally on android or when using back camera on iOS.
           const flipX = IS_ANDROID || cameraType === Camera.Constants.Type.back;
-          const x = flipX ? OUTPUT_TENSOR_WIDTH - k.x : k.x;
+          const x = flipX ? getOutputTensorWidth() - k.x : k.x;
           const y = k.y;
           const cx =
             (x / getOutputTensorWidth()) *

--- a/react-native/pose-detection/App.tsx
+++ b/react-native/pose-detection/App.tsx
@@ -9,6 +9,7 @@ import * as ScreenOrientation from 'expo-screen-orientation';
 import { cameraWithTensors } from '@tensorflow/tfjs-react-native';
 import Svg, { Circle } from 'react-native-svg';
 import { ExpoWebGLRenderingContext } from 'expo-gl';
+import { CameraType } from 'expo-camera/build/Camera.types';
 
 // tslint:disable-next-line: variable-name
 const TensorCamera = cameraWithTensors(Camera);
@@ -48,6 +49,7 @@ export default function App() {
   const [fps, setFps] = useState(0);
   const [orientation, setOrientation] =
     useState<ScreenOrientation.Orientation>();
+  const [cameraType, setCameraType] = useState<CameraType>(CameraType.front);
 
   useEffect(() => {
     async function prepare() {
@@ -157,6 +159,27 @@ export default function App() {
     );
   };
 
+  const renderCameraTypeSwitcher = () => {
+    return (
+      <View
+        style={styles.cameraTypeSwitcher}
+        onTouchEnd={handleSwitchCameraType}
+      >
+        <Text>
+          Switch to {cameraType === CameraType.front ? 'back' : 'front'} camera
+        </Text>
+      </View>
+    );
+  };
+
+  const handleSwitchCameraType = () => {
+    if (cameraType === CameraType.front) {
+      setCameraType(CameraType.back);
+    } else {
+      setCameraType(CameraType.front);
+    }
+  };
+
   const isPortrait = () => {
     return (
       orientation === ScreenOrientation.Orientation.PORTRAIT_UP ||
@@ -223,7 +246,7 @@ export default function App() {
           ref={cameraRef}
           style={styles.camera}
           autorender={AUTO_RENDER}
-          type={Camera.Constants.Type.front}
+          type={cameraType}
           // tensor related props
           resizeWidth={getOutputTensorWidth()}
           resizeHeight={getOutputTensorHeight()}
@@ -233,6 +256,7 @@ export default function App() {
         />
         {renderPose()}
         {renderFps()}
+        {renderCameraTypeSwitcher()}
       </View>
     );
   }
@@ -274,6 +298,17 @@ const styles = StyleSheet.create({
     top: 10,
     left: 10,
     width: 80,
+    alignItems: 'center',
+    backgroundColor: 'rgba(255, 255, 255, .7)',
+    borderRadius: 2,
+    padding: 8,
+    zIndex: 20,
+  },
+  cameraTypeSwitcher: {
+    position: 'absolute',
+    top: 10,
+    right: 10,
+    width: 180,
     alignItems: 'center',
     backgroundColor: 'rgba(255, 255, 255, .7)',
     borderRadius: 2,

--- a/react-native/pose-detection/README.md
+++ b/react-native/pose-detection/README.md
@@ -3,7 +3,8 @@
 A quick demo for running [TFJS Pose Detection][posedetection] model
 ([MoveNet.SinglePose.Ligntning][tfhub]) using
 [TFJS React Native][tfjs-react-native] in an Expo project. It supports both
-portrait and landscape mode. Only the keypoints are rendered in the demo.
+portrait and landscape mode with front and back camera. Only the keypoints are
+rendered in the demo.
 
 To run it locally:
 

--- a/react-native/pose-detection/package.json
+++ b/react-native/pose-detection/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build-dep": "cd ../../../tfjs/tfjs-react-native && yarn build-npm",
     "copy-dep": "rm -rf node_modules/@tensorflow/tfjs-react-native/dist/* && cp -rf ../../../tfjs/tfjs-react-native/dist/* node_modules/@tensorflow/tfjs-react-native/dist/",
-    "start": "expo start --tunnel"
+    "start": "expo start"
   },
   "dependencies": {
     "@mediapipe/pose": "~0.4.0",

--- a/react-native/pose-detection/package.json
+++ b/react-native/pose-detection/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build-dep": "cd ../../../tfjs/tfjs-react-native && yarn build-npm",
     "copy-dep": "rm -rf node_modules/@tensorflow/tfjs-react-native/dist/* && cp -rf ../../../tfjs/tfjs-react-native/dist/* node_modules/@tensorflow/tfjs-react-native/dist/",
-    "start": "expo start"
+    "start": "expo start --tunnel"
   },
   "dependencies": {
     "@mediapipe/pose": "~0.4.0",

--- a/react-native/pose-detection/yarn.lock
+++ b/react-native/pose-detection/yarn.lock
@@ -2215,10 +2215,10 @@
   resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-layers/-/tfjs-layers-3.9.0.tgz#0e05116bcd7f55eb39cff322e9940fa46c9fbda2"
   integrity sha512-25I20Oy17YZ3y0x/pabeiN6/vai0vqMQ85/Bp0GLOpcN2kmOLcItdWOAqFW5YPI2nrTqnpNQyk9zhmIh8f6X4w==
 
-"@tensorflow/tfjs-react-native@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-react-native/-/tfjs-react-native-0.7.0.tgz#7e82c34db1a0055f798c94aa7019906cb3ac4916"
-  integrity sha512-2uA4d0BYh44JXqJ1n9wTuGGZ1OP3y9om6aQRFWt2MWrAoNceO2iwBIXdwfqzHiY3T/mBfH/sCp39FDa0L8LWEw==
+"@tensorflow/tfjs-react-native@0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@tensorflow/tfjs-react-native/-/tfjs-react-native-0.8.0.tgz#1b4b8c0cd50266534c5ff990823960ca190fa042"
+  integrity sha512-iZKCTvX0cxMJWs+ma32x9+CijANW7IH9EaTK2L3FXvR8Qqe/ueW8SUMOh0L3QusPIWE+ggtrGIfsv4OWo1xf/g==
   dependencies:
     base64-js "^1.3.0"
     buffer "^5.2.1"


### PR DESCRIPTION
- Add a button to allow users to switch between front and back camera.
- Correctly support back camera in iOS (no changes for Android):
   - Flip x coordinates when using the back camera.
   - Use the correct angles to rotate the view for landscape mode when using the back camera  
- Correctly cancel update loop when the root component (app) is unmounted.
- Update README

Tested on iOS and Android.

Fixes https://github.com/tensorflow/tfjs/issues/5897

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/637)
<!-- Reviewable:end -->
