### PR TITLE
Downgrade the yarn.lock'd resolved version for colors@^1.1.2 to point to v1.4.0 instead of the deleted v1.4.2 inside the react-native/pose-detection example

### DIFF
--- a/react-native/pose-detection/yarn.lock
+++ b/react-native/pose-detection/yarn.lock
@@ -4862,9 +4862,9 @@ colorette@^1.0.7, colorette@^1.3.0:
   integrity sha512-ecORCqbSFP7Wm8Y6lyqMJjexBQqXSF7SSeaTyGGphogUjBlFP9m9o08wy86HL2uB7fMTxtOUzLMk7ogKcxMg1w==
 
 colors@^1.1.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.2.tgz#cd4fe227412ca2c75bb6f5683ec2e5e68de4f317"
-  integrity sha512-5QhJWPFZqkKIieXJPpCprdOytvH7v0AGWpu9K2jZ4LWkGg3dVBNoYPgGGRpEsc0jb8Boy0ElYrdjH9uXfhRSqw==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
+  integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
 combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"


### PR DESCRIPTION
See this issue: https://github.com/tensorflow/tfjs/issues/6218
Fixes https://github.com/tensorflow/tfjs/issues/6218

The committed `yarn.lock` file specifies a dependency resolution block for the indirect dependency colors@^1.1.2 that resolves to the now deleted version 1.4.2. This causes issues when using npm to install dependencies (yarn works just fine).

The fix is to change the dependency resolution block (manually) to resolve to the latest valid version, 1.4.0, which involves changing the `version`, `resolved`, and `integrity` fields accordingly. See the latest version of colors available on the npm registry: https://www.npmjs.com/package/colors

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/tensorflow/tfjs-examples/738)
<!-- Reviewable:end -->
