### PR TITLE
Remove 'main' field from addition-rnn

### DIFF
--- a/addition-rnn-webworker/package.json
+++ b/addition-rnn-webworker/package.json
@@ -2,7 +2,6 @@
   "name": "tfjs-examples-addition-rnn",
   "version": "0.1.0",
   "description": "",
-  "main": "index.js",
   "license": "Apache-2.0",
   "private": true,
   "engines": {

--- a/addition-rnn/package.json
+++ b/addition-rnn/package.json
@@ -2,7 +2,6 @@
   "name": "tfjs-examples-addition-rnn",
   "version": "0.1.0",
   "description": "",
-  "main": "index.js",
   "license": "Apache-2.0",
   "private": true,
   "engines": {


### PR DESCRIPTION
The main field is not necessary since this package is never imported. It's just a demo site.