### PR TITLE
Update broken link in README.md for keras VAE example code

### DIFF
--- a/fashion-mnist-vae/README.md
+++ b/fashion-mnist-vae/README.md
@@ -5,7 +5,7 @@ This example shows you how to train a [variational autoenconder](https://blog.ke
 The model will be trained on the [Fashion MNIST](https://github.com/zalandoresearch/fashion-mnist) dataset.
 
 This example is a port of the code for a multilayer perceptron based variational
-autoencoder from this link https://github.com/keras-team/keras/blob/master/examples/variational_autoencoder.py See [this tutorial](https://blog.keras.io/building-autoencoders-in-keras.html) for a description of how autoencoders work.
+autoencoder from this link https://github.com/keras-team/keras-io/blob/master/examples/generative/vae.py See [this tutorial](https://blog.keras.io/building-autoencoders-in-keras.html) for a description of how autoencoders work.
 
 ## Prepare the node environment:
 ```sh


### PR DESCRIPTION
I have updated broken link on this [page](https://github.com/tensorflow/tfjs-examples/tree/master/fashion-mnist-vae#tensorflowjs-training-a-variational-autoencoder) for keras VAE example code under this paragraph **"This example is a port of the code for a multilayer perceptron based variational autoencoder from this link https://github.com/keras-team/keras/blob/master/examples/variational_autoencoder.py See [this tutorial](https://blog.keras.io/building-autoencoders-in-keras.html) for a description of how autoencoders work. "** so please do the needful. Thank you!