### PR TITLE
Update 02 broken links of lstm-text-generation example in README.md

### DIFF
--- a/lstm-text-generation/README.md
+++ b/lstm-text-generation/README.md
@@ -27,13 +27,13 @@ stacked LSTM layers.
 
 This example also illustrates how to save a trained model in the browser's
 IndexedDB using TensorFlow.js's
-[model saving API](https://js.tensorflow.org/tutorials/model-save-load.html),
+[model saving API](https://www.tensorflow.org/js/guide/save_load),
 so that the result of the training
 may persist across browser sessions. Once a previously-trained model is loaded
 from the IndexedDB, it can be used in text generation and/or further training.
 
 This example is inspired by the LSTM text generation example from Keras:
-https://github.com/keras-team/keras/blob/master/examples/lstm_text_generation.py
+https://github.com/keras-team/keras-io/blob/master/examples/generative/lstm_character_level_text_generation.py
 
 ## Usage
 


### PR DESCRIPTION
I have updated 02 broken links on this [page](https://github.com/tensorflow/tfjs-examples/tree/master/lstm-text-generation#overview), one is for **model saving API** hyperlink on this line "This example also illustrates how to save a trained model in the browser's IndexedDB using TensorFlow.js's [model saving API](https://js.tensorflow.org/tutorials/model-save-load.html)".

Second is for **LSTM text generation example from Keras** on this line "This example is inspired by the LSTM text generation example from Keras: https://github.com/keras-team/keras/blob/master/examples/lstm_text_generation.py" at the moment I have updated broken link to this link https://github.com/keras-team/keras-io/blob/master/examples/generative/lstm_character_level_text_generation.py because I believe there is no previous LSTM text generation example from Keras available now, I checked on [keras website ](https://keras.io/examples/) under Text generation example section so I recommend that we change the broken link to https://github.com/keras-team/keras-io/blob/master/examples/generative/lstm_character_level_text_generation.py If you agree, please do the needful. Thank you!
