### PR TITLE
Update broken link in tfjs-examples/sentiment README.md

### DIFF
--- a/sentiment/README.md
+++ b/sentiment/README.md
@@ -13,7 +13,7 @@ sentiment.  This dataset is
 and the models were trained in Keras as well, based on the
 [imdb_cnn](https://github.com/keras-team/keras/blob/master/examples/imdb_cnn.py)
 and
-[imdb_lstm](https://github.com/keras-team/keras/blob/master/examples/imdb_lstm.py)
+[imdb_lstm](https://github.com/keras-team/keras/blob/master/examples/keras_io/nlp/bidirectional_lstm_imdb.py)
 examples.
 
 To launch the demo, do


### PR DESCRIPTION
I have updated broken link on this [page](https://github.com/tensorflow/tfjs-examples/edit/master/sentiment/README.md) for imdb_lstm hyperlink on this paragraph "**Two model variants are provided (CNN and LSTM). These were trained on a set of 25,000 movie reviews from IMDB, labelled as having positive or negative sentiment. This dataset is [provided by Python Keras](https://keras.io/datasets/#imdb-movie-reviews-sentiment-classification), and the models were trained in Keras as well, based on the [imdb_cnn](https://github.com/keras-team/keras/blob/master/examples/imdb_cnn.py) and [imdb_lstm](https://github.com/keras-team/keras/blob/master/examples/imdb_lstm.py) examples.**" and there is broken link for imdb_cnn hyperlink also but keras team haven't updated/added that example so at the moment I'm not sure which link we should update for that hyperlink so please do the needful. Thank you!
