### PR TITLE
Update broken link for lstm_seq2seq hyperlink in README.md

### DIFF
--- a/translation/README.md
+++ b/translation/README.md
@@ -41,7 +41,7 @@ The model was trained in Node.js with Tensorflow.js, which the model code is con
 python python/translation.py ${DATA_PATH}
 ```
 
-The model was trained in Python Keras, based on the [lstm_seq2seq](https://github.com/keras-team/keras/blob/master/examples/lstm_seq2seq.py)
+The model was trained in Python Keras, based on the [lstm_seq2seq](https://github.com/keras-team/keras-io/blob/master/examples/nlp/lstm_seq2seq.py)
 example.
 
 ## LAUNCH DEMO


### PR DESCRIPTION
I have updated broken link on this [page](https://github.com/tensorflow/tfjs-examples/tree/master/translation) under this [section](https://github.com/tensorflow/tfjs-examples/tree/master/translation#python-version) on this line **"The model was trained in Python Keras, based on the [lstm_seq2seq](https://github.com/keras-team/keras/blob/master/examples/lstm_seq2seq.py) example."** for `lstm_seq2seq hyperlink` to workable link so please do the needful. Thank you!