### PR TITLE
Update broken link for mnist_transfer_cnn example in README.md

### DIFF
--- a/mnist-transfer-cnn/README.md
+++ b/mnist-transfer-cnn/README.md
@@ -4,7 +4,7 @@ This demo shows how to perform transfer learning using the Layers API of
 TensorFlow.js.
 
 It follows the procedure outlined in the Keras
-[mnist_transfer_cnn](https://github.com/keras-team/keras/blob/master/examples/mnist_transfer_cnn.py)
+[mnist_transfer_cnn](https://github.com/tensorflow/tfjs-examples/blob/master/mnist-transfer-cnn/python/mnist_transfer_cnn.py)
 example.
 
  * A simple convnet was trained in Python Keras on only the first 5 digits [0..4] from the MNIST dataset.  The resulting model is hosted at a URL and loaded into TensorFlow.js using


### PR DESCRIPTION
Hi, Team
I've identified broken link for [mnist_transfer_cnn](https://github.com/keras-team/keras/blob/master/examples/mnist_transfer_cnn.py) python example on this [page](https://github.com/tensorflow/tfjs-examples/tree/master/mnist-transfer-cnn) and based on my understanding, the Keras team has removed this example from the [Keras examples ](https://keras.io/examples/vision/)section.

To address this issue, I have temporarily updated the broken link with the [mnist_transfer_cnn.py](https://github.com/tensorflow/tfjs-examples/blob/master/mnist-transfer-cnn/python/mnist_transfer_cnn.py) file located in the **Python** folder.

Moving forward, I suggest we consider two options:

- Remove the reference: We can remove the statement **"It follows the procedure outlined in the Keras [mnist_transfer_cnn](https://github.com/keras-team/keras/blob/master/examples/mnist_transfer_cnn.py) example."**.
- Replace with a similar example: We can replace the reference with a link to a relevant example on the MNIST dataset from a reputable source such as Medium or Towards Data Science. This would provide users with an alternative learning resource.

I appreciate your time and look forward to your feedback on the proposed solutions. Thank you.